### PR TITLE
Bump MarketingCloudSDK to 8.0.13 and fix typing issues

### DIFF
--- a/ios/ExpoMarketingCloudSdk.podspec
+++ b/ios/ExpoMarketingCloudSdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MarketingCloudSDK', '8.0.10'
+  s.dependency 'MarketingCloudSDK', '8.0.13'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ExpoMarketingCloudSdk.podspec
+++ b/ios/ExpoMarketingCloudSdk.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
+  s.dependency 'EXNotifications'
   s.dependency 'MarketingCloudSDK', '8.0.13'
 
   # Swift/Objective-C compatibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@allboatsrise/expo-marketingcloudsdk",
   "author": "All Boats Rise Inc.",
-  "version": "48.0.0",
+  "version": "48.0.1",
   "license": "MIT",
   "description": "Expo module for Salesforce Marketing Cloud SDK",
   "homepage": "https://github.com/allboatsrise/expo-marketingcloudsdk",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export async function setSystemToken(token: string): Promise<void> {
 }
 
 export async function getAttributes(): Promise<Record<string, string>> {
-  return await ExpoMarketingCloudSdkModule.getAttributes() || {};
+  return await ExpoMarketingCloudSdkModule.getAttributes() ?? {};
 }
 
 export async function setAttribute(key: string, value: string): Promise<void> {
@@ -44,7 +44,7 @@ export async function removeTag(tag: string): Promise<void> {
 }
 
 export async function getTags(): Promise<string[]> {
-  return await ExpoMarketingCloudSdkModule.getTags() || [];
+  return await ExpoMarketingCloudSdkModule.getTags() ?? [];
 }
 
 export async function setContactKey(contactKey: string): Promise<void> {
@@ -56,7 +56,7 @@ export async function getContactKey(): Promise<string> {
 }
 
 export async function getSdkState(): Promise<Record<string, unknown>> {
-  const state = await ExpoMarketingCloudSdkModule.getSdkState() || {};
+  const state = await ExpoMarketingCloudSdkModule.getSdkState() ?? {};
   return JSON.parse(state);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export async function setSystemToken(token: string): Promise<void> {
 }
 
 export async function getAttributes(): Promise<Record<string, string>> {
-  return await ExpoMarketingCloudSdkModule.getAttributes();
+  return await ExpoMarketingCloudSdkModule.getAttributes() || {};
 }
 
 export async function setAttribute(key: string, value: string): Promise<void> {
@@ -44,7 +44,7 @@ export async function removeTag(tag: string): Promise<void> {
 }
 
 export async function getTags(): Promise<string[]> {
-  return await ExpoMarketingCloudSdkModule.getTags();
+  return await ExpoMarketingCloudSdkModule.getTags() || [];
 }
 
 export async function setContactKey(contactKey: string): Promise<void> {
@@ -56,7 +56,7 @@ export async function getContactKey(): Promise<string> {
 }
 
 export async function getSdkState(): Promise<Record<string, unknown>> {
-  const state = await ExpoMarketingCloudSdkModule.getSdkState();
+  const state = await ExpoMarketingCloudSdkModule.getSdkState() || {};
   return JSON.parse(state);
 }
 


### PR DESCRIPTION
As mentioned in this issue: #8, marketing cloud SDK 8.0.10 is no longer working for iOS. We bumped the version and fixed some typing issues that we noticed. Tested methods:

- setSystemToken
- addLogListener
- enablePush
- isPushEnabled
- getAttributes
- setAttribute