### PR TITLE
fix - missing `EXNotifications` podspec dependency

### DIFF
--- a/ios/ExpoMarketingCloudSdk.podspec
+++ b/ios/ExpoMarketingCloudSdk.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
+  s.dependency 'EXNotifications'
   s.dependency 'MarketingCloudSDK', '8.0.10'
 
   # Swift/Objective-C compatibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@allboatsrise/expo-marketingcloudsdk",
   "author": "All Boats Rise Inc.",
-  "version": "48.0.0",
+  "version": "48.0.1",
   "license": "MIT",
   "description": "Expo module for Salesforce Marketing Cloud SDK",
   "homepage": "https://github.com/allboatsrise/expo-marketingcloudsdk",


### PR DESCRIPTION
Addresses build issues on iOS.

https://github.com/allboatsrise/expo-marketingcloudsdk/issues/6
https://github.com/allboatsrise/expo-marketingcloudsdk/issues/11