### PR TITLE
chore - bump sdk versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -94,5 +94,5 @@ dependencies {
   implementation project(":expo-notifications")
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation 'com.facebook.react:react-native:+'
-  api "com.salesforce.marketingcloud:marketingcloudsdk:8.0.8"
+  api "com.salesforce.marketingcloud:marketingcloudsdk:8.0.9"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
 group = 'expo.modules.marketingcloudsdk'
-version = '47.0.0'
+version = '48.0.2'
 
 buildscript {
   def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
@@ -77,7 +77,7 @@ android {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 31)
     versionCode 1
-    versionName "47.0.0"
+    versionName "48.0.2"
   }
   lintOptions {
     abortOnError false

--- a/ios/ExpoMarketingCloudSdk.podspec
+++ b/ios/ExpoMarketingCloudSdk.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'EXNotifications'
-  s.dependency 'MarketingCloudSDK', '8.0.10'
+  s.dependency 'MarketingCloudSDK', '8.0.13'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@allboatsrise/expo-marketingcloudsdk",
   "author": "All Boats Rise Inc.",
-  "version": "48.0.1",
+  "version": "48.0.2",
   "license": "MIT",
   "description": "Expo module for Salesforce Marketing Cloud SDK",
   "homepage": "https://github.com/allboatsrise/expo-marketingcloudsdk",

--- a/plugin/src/android/index.ts
+++ b/plugin/src/android/index.ts
@@ -29,7 +29,7 @@ const withConfigureRepository: ConfigPlugin<MarketingCloudSdkPluginProps> = (con
   return withAppBuildGradle(config, async config => {
     config.modResults.contents = mergeContents({
       src: config.modResults.contents,
-      newSrc: `    implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.0.8'`,
+      newSrc: `    implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.0.9'`,
       anchor: /dependencies\s?{/,
       offset: 1,
       tag: '@allboatsrise/expo-marketingcloudsdk(maven:dependencies)',


### PR DESCRIPTION
Bumped MarketingCloudSDK versions to latest, but I haven't tested the actual build myself.

|  platform  | before | after |
| --- | --- | --- |
| ios | 8.0.10 | [8.0.13](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/#version-8013) |
| android | 8.0.8 | [8.0.9](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/#version-809) |