### PR TITLE
chore - upgrade to latest sdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,5 +92,5 @@ dependencies {
   implementation project(":expo-notifications")
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation 'com.facebook.react:react-native:+'
-  api "com.salesforce.marketingcloud:marketingcloudsdk:8.0.9"
+  api "com.salesforce.marketingcloud:marketingcloudsdk:8.1.4"
 }

--- a/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkApplicationLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkApplicationLifecycleListener.kt
@@ -21,6 +21,14 @@ class ExpoMarketingCloudSdkApplicationLifecycleListener : ApplicationLifecycleLi
       SFMCSdk.setLogging(LogLevel.DEBUG, LogListener.AndroidLogger())
       MarketingCloudSdk.setLogLevel(MCLogListener.VERBOSE)
       MarketingCloudSdk.setLogListener(MCLogListener.AndroidLogListener())
+      SFMCSdk.requestSdk { sdk ->
+        sdk.mp { push ->
+          push.registrationManager.registerForRegistrationEvents {
+            // Log the registration on successful sends to the MC
+            Log.i("~#SFMC-expo", "Registration: $it")
+          }
+        }
+      }
     }
 
     // Configure Salesforce Marketing Cloud SDK

--- a/ios/ExpoMarketingCloudSdk.podspec
+++ b/ios/ExpoMarketingCloudSdk.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'EXNotifications'
-  s.dependency 'MarketingCloudSDK', '8.0.13'
+  s.dependency 'MarketingCloudSDK', '8.1.1'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ExpoMarketingCloudSdkModule.swift
+++ b/ios/ExpoMarketingCloudSdkModule.swift
@@ -41,70 +41,102 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
     }
 
     AsyncFunction("isPushEnabled") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.pushEnabled())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.pushEnabled())
+      }
     }
 
     AsyncFunction("enablePush") { (promise: Promise) in
-      SFMCSdk.mp.setPushEnabled(true)
-      promise.resolve(SFMCSdk.mp.pushEnabled())
+      SFMCSdk.requestPushSdk { mp in
+        mp.setPushEnabled(true)
+        promise.resolve(mp.pushEnabled())
+      }
     }
 
     AsyncFunction("disablePush") { (promise: Promise) in
-      SFMCSdk.mp.setPushEnabled(false)
-      promise.resolve(SFMCSdk.mp.pushEnabled())
+      SFMCSdk.requestPushSdk { mp in
+        mp.setPushEnabled(false)
+        promise.resolve(mp.pushEnabled())
+      }
     }
 
     AsyncFunction("getSystemToken") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.deviceToken())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.deviceToken())
+      }
     }
     
     AsyncFunction("setSystemToken") { (token: String, promise: Promise) in
       do {
         let token = try ExpoMarketingCloudSdkDeviceToken.init(hexString: token)
-        SFMCSdk.mp.setDeviceToken(token.data)
-        promise.resolve(SFMCSdk.mp.deviceToken())
+        
+        SFMCSdk.requestPushSdk { mp in
+          mp.setDeviceToken(token.data)
+          promise.resolve(mp.deviceToken())
+        }
       } catch {
         promise.reject("invalid-hex-token", "Failed to convert token to data type")
       }
     }
 
     AsyncFunction("getDeviceID") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.deviceIdentifier())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.deviceIdentifier())
+      }
     }
 
     AsyncFunction("getAttributes") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.attributes())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.attributes())
+      }
     }
 
     AsyncFunction("setAttribute") { (key: String, value: String, promise: Promise) in
       SFMCSdk.identity.setProfileAttribute(key, value)
-      promise.resolve(SFMCSdk.mp.attributes())
+      
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.attributes())
+      }
     }
 
     AsyncFunction("clearAttribute") { (key: String, promise: Promise) in
       SFMCSdk.identity.clearProfileAttribute(key: key)
-      promise.resolve(SFMCSdk.mp.attributes())
+      
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.attributes())
+      }
     }
 
     AsyncFunction("addTag") { (tag: String, promise: Promise) in
-      promise.resolve(SFMCSdk.mp.addTag(tag))
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.addTag(tag))
+      }
     }
 
     AsyncFunction("removeTag") { (tag: String, promise: Promise) in
-      promise.resolve(SFMCSdk.mp.removeTag(tag))
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.removeTag(tag))
+      }
     }
 
     AsyncFunction("getTags") { (promise: Promise) in
-      promise.resolve(Array(arrayLiteral: SFMCSdk.mp.tags()))
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(Array(arrayLiteral: mp.tags()))
+      }
     }
 
     AsyncFunction("setContactKey") { (contactKey: String, promise: Promise) in
       SFMCSdk.identity.setProfileId(contactKey)
-      promise.resolve(SFMCSdk.mp.contactKey())
+      
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.contactKey())
+      }
     }
 
     AsyncFunction("getContactKey") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.contactKey())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.contactKey())
+      }
     }
 
     AsyncFunction("getSdkState") { (promise: Promise) in
@@ -118,63 +150,90 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
     }
 
     AsyncFunction("deleteMessage") { (messageId: String, promise: Promise) in
-      promise.resolve(SFMCSdk.mp.markMessageWithIdDeleted(messageId: messageId))
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.markMessageWithIdDeleted(messageId: messageId))
+      }
     }
 
     AsyncFunction("getDeletedMessageCount") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.getDeletedMessagesCount())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getDeletedMessagesCount())
+      }
     }
 
     AsyncFunction("getDeletedMessages") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.getDeletedMessages())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getDeletedMessages())
+      }
     }
 
-    AsyncFunction("getMessageCount") { (promise: Promise) in      promise.resolve(SFMCSdk.mp.getAllMessagesCount())
+    AsyncFunction("getMessageCount") { (promise: Promise) in
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getAllMessagesCount())
+      }
     }
 
     AsyncFunction("getMessages") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.getAllMessages())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getAllMessages())
+      }
     }
 
     AsyncFunction("getReadMessageCount") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.getReadMessagesCount())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getReadMessagesCount())
+      }
     }
 
     AsyncFunction("getReadMessages") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.getReadMessages())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getReadMessages())
+      }
     }
 
     AsyncFunction("getUnreadMessageCount") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.getUnreadMessagesCount())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getUnreadMessagesCount())
+      }
     }
 
     AsyncFunction("getUnreadMessages") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.getUnreadMessages())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.getUnreadMessages())
+      }
     }
 
     AsyncFunction("markAllMessagesDeleted") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.markAllMessagesDeleted())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.markAllMessagesDeleted())
+      }
     }
 
     AsyncFunction("markAllMessagesRead") { (promise: Promise) in
-      promise.resolve(SFMCSdk.mp.markAllMessagesRead())
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.markAllMessagesRead())
+      }
     }
 
     AsyncFunction("refreshInbox") { (promise: Promise) in
-      let successful = SFMCSdk.mp.refreshMessages()
-      if (successful == false) {
-        promise.resolve(false)
-      } else {
-        // resolve previous promise if one exists
-        self.refreshInboxPromise?.resolve(false)
-        
-        // queue latest promise
-        self.refreshInboxPromise = promise
+      SFMCSdk.requestPushSdk { mp in
+        let successful = mp.refreshMessages()
+        if (successful == false) {
+          promise.resolve(false)
+        } else {
+          // resolve previous promise if one exists
+          self.refreshInboxPromise?.resolve(false)
+          
+          // queue latest promise
+          self.refreshInboxPromise = promise
+        }
       }
     }
 
     AsyncFunction("setMessageRead") { (messageId: String, promise: Promise) in
-      promise.resolve(SFMCSdk.mp.markMessageWithIdRead(messageId: messageId))
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.markMessageWithIdRead(messageId: messageId))
+      }
     }
   }
   

--- a/ios/ExpoMarketingCloudSdkModule.swift
+++ b/ios/ExpoMarketingCloudSdkModule.swift
@@ -16,7 +16,7 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
     Name("ExpoMarketingCloudSdk")
 
     // Defines event names that the module can send to JavaScript.
-    Events("onLog", "onInboxResponse")
+    Events("onLog", "onInboxResponse", "onRegistrationResponseSucceeded")
     
     OnStartObserving {
       if (logger == nil) {
@@ -28,12 +28,16 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
       NotificationCenter.default.addObserver(self, selector: #selector(self.inboxMessagesNewInboxMessagesListener), name: NSNotification.Name.SFMCInboxMessagesNewInboxMessages, object: nil)
       
       NotificationCenter.default.addObserver(self, selector: #selector(self.inboxMessagesRefreshCompleteListener), name: NSNotification.Name.SFMCInboxMessagesRefreshComplete, object: nil)
+      
+      NotificationCenter.default.addObserver(self, selector: #selector(self.foundationRegistrationResponseSucceededListener), name: NSNotification.Name.SFMCFoundationRegistrationResponseSucceeded, object: nil)
     }
     
     OnStopObserving {
       NotificationCenter.default.removeObserver(self, name: NSNotification.Name.SFMCInboxMessagesNewInboxMessages, object: nil)
       
       NotificationCenter.default.removeObserver(self, name: NSNotification.Name.SFMCInboxMessagesRefreshComplete, object: nil)
+      
+      NotificationCenter.default.removeObserver(self, name: NSNotification.Name.SFMCFoundationRegistrationResponseSucceeded, object: nil)
     }
 
     AsyncFunction("isPushEnabled") { (promise: Promise) in
@@ -196,5 +200,10 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
       "category": category.rawValue,
       "message": message
     ])
+  }
+  
+  @objc
+  func foundationRegistrationResponseSucceededListener(response: [String: Any]) {
+    sendEvent("onRegistrationResponseSucceeded", ["response": response])
   }
 }

--- a/ios/ExpoMarketingCloudSdkModule.swift
+++ b/ios/ExpoMarketingCloudSdkModule.swift
@@ -29,7 +29,11 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
       
       NotificationCenter.default.addObserver(self, selector: #selector(self.inboxMessagesRefreshCompleteListener), name: NSNotification.Name.SFMCInboxMessagesRefreshComplete, object: nil)
       
-      NotificationCenter.default.addObserver(self, selector: #selector(self.foundationRegistrationResponseSucceededListener), name: NSNotification.Name.SFMCFoundationRegistrationResponseSucceeded, object: nil)
+      SFMCSdk.requestPushSdk { mp in
+        mp.setRegistrationCallback() { response in
+          self.sendEvent("onRegistrationResponseSucceeded", ["response": response])
+        }
+      }
     }
     
     OnStopObserving {
@@ -37,7 +41,9 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
       
       NotificationCenter.default.removeObserver(self, name: NSNotification.Name.SFMCInboxMessagesRefreshComplete, object: nil)
       
-      NotificationCenter.default.removeObserver(self, name: NSNotification.Name.SFMCFoundationRegistrationResponseSucceeded, object: nil)
+      SFMCSdk.requestPushSdk { mp in
+        mp.unsetRegistrationCallback()
+      }
     }
 
     AsyncFunction("isPushEnabled") { (promise: Promise) in
@@ -259,10 +265,5 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
       "category": category.rawValue,
       "message": message
     ])
-  }
-  
-  @objc
-  func foundationRegistrationResponseSucceededListener(response: [String: Any]) {
-    sendEvent("onRegistrationResponseSucceeded", ["response": response])
   }
 }

--- a/ios/ExpoMarketingCloudSdkNotificationsDelegate.swift
+++ b/ios/ExpoMarketingCloudSdkNotificationsDelegate.swift
@@ -5,12 +5,16 @@ import MarketingCloudSDK
 class ExpoMarketingCloudSdkNotificationsDelegate : NSObject, EXNotificationsDelegate {
   @objc
   public func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) async -> UIBackgroundFetchResult {
-    SFMCSdk.mp.setNotificationUserInfo(userInfo)
+    SFMCSdk.requestPushSdk { mp in
+      mp.setNotificationUserInfo(userInfo)
+    }
     return UIBackgroundFetchResult.newData
   }
   @objc
   public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-    SFMCSdk.mp.setNotificationRequest(response.notification.request)
+    SFMCSdk.requestPushSdk { mp in
+      mp.setNotificationRequest(response.notification.request)
+    }
     completionHandler()
   }
 }

--- a/plugin/src/android/index.ts
+++ b/plugin/src/android/index.ts
@@ -29,7 +29,7 @@ const withConfigureRepository: ConfigPlugin<MarketingCloudSdkPluginProps> = (con
   return withAppBuildGradle(config, async config => {
     config.modResults.contents = mergeContents({
       src: config.modResults.contents,
-      newSrc: `    implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.0.9'`,
+      newSrc: `    implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.1.4'`,
       anchor: /dependencies\s?{/,
       offset: 1,
       tag: '@allboatsrise/expo-marketingcloudsdk(maven:dependencies)',

--- a/src/ExpoMarketingCloudSdk.types.ts
+++ b/src/ExpoMarketingCloudSdk.types.ts
@@ -31,3 +31,33 @@ export type InboxMessage = {
 export type InboxResponsePayload = {
   messages: InboxMessage[]
 }
+
+export type RegistrationResponseSucceededPayload = {
+  response: {
+    "quietPushEnabled" : boolean,
+    "location_Enabled" : boolean,
+    "registrationId" : string,
+    "timeZone" : string,
+    "locale" : string,
+    "etAppId" : string,
+    "attributes" : Array<
+      {
+        "key" : string,
+        "value" : string
+      }
+    >,
+    "proximity_Enabled" : boolean,
+    "subscriberKey" : string,
+    "platform" : string,
+    "sdk_Version" : string,
+    "language" : string,
+    "app_Version" : string,
+    "deviceID" : string,
+    "tags" : string[],
+    "hwid" : string,
+    "push_Enabled" : boolean,
+    "device_Token" : string,
+    "dST" : boolean,
+    "platform_Version" : string
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,8 @@ export async function getContactKey(): Promise<string | null> {
   return await ExpoMarketingCloudSdkModule.getContactKey();
 }
 
-export async function getSdkState(): Promise<Record<string, unknown>> {
-  const state: string = await ExpoMarketingCloudSdkModule.getSdkState();
-  return JSON.parse(state);
+export async function getSdkState(): Promise<string> {
+  return await ExpoMarketingCloudSdkModule.getSdkState();
 }
 
 export async function track(name: string, attributes: Record<string, string>): Promise<true> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,4 +134,4 @@ export function addRegistrationResponseSucceededListener(listener: (event: Regis
   return emitter.addListener<RegistrationResponseSucceededPayload>('onRegistrationResponseSucceeded', listener)
 }
 
-export { LogEventPayload, InboxResponsePayload, InboxMessage }
+export { LogEventPayload, InboxResponsePayload, InboxMessage, RegistrationResponseSucceededPayload }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { NativeModulesProxy, EventEmitter, Subscription } from 'expo-modules-core';
 
 import ExpoMarketingCloudSdkModule from './ExpoMarketingCloudSdkModule';
-import { InboxResponsePayload, LogEventPayload, InboxMessage } from './ExpoMarketingCloudSdk.types';
+import { InboxResponsePayload, LogEventPayload, InboxMessage, RegistrationResponseSucceededPayload } from './ExpoMarketingCloudSdk.types';
 
 export async function isPushEnabled(): Promise<boolean> {
   return await ExpoMarketingCloudSdkModule.isPushEnabled();
@@ -128,6 +128,10 @@ export function addLogListener(listener: (event: LogEventPayload) => void): Subs
 
 export function addInboxResponseListener(listener: (event: InboxResponsePayload) => void): Subscription {
   return emitter.addListener<InboxResponsePayload>('onInboxResponse', listener)
+}
+
+export function addRegistrationResponseSucceededListener(listener: (event: RegistrationResponseSucceededPayload) => void): Subscription {
+  return emitter.addListener<RegistrationResponseSucceededPayload>('onRegistrationResponseSucceeded', listener)
 }
 
 export { LogEventPayload, InboxResponsePayload, InboxMessage }


### PR DESCRIPTION
- bump ios sdk to 8.1.1
- bump android sdk to 8.1.4
- added support for `onRegistrationResponseSucceeded` event
  ```
  useEffect(() => {
    const subscription = MarketingCloud.addRegistrationResponseSucceededListener((data) => {
      console.log('registration response', data.response)
    })

    return () => {
      subscription.remove()
    }
  }, [loggingEnabled])
  ```
- `compileSdkVersion` and `minSdkVersion` must be bumped higher for Expo SDK 49 in `app.config.js`.
  ```
    plugins: [
      [
        'expo-build-properties',
        {
          android: {
            minSdkVersion: 24,
            compileSdkVersion: 34,
          }
        }
      ]
    ]
  ```