### PR TITLE
iOS Notification Extension to enable rich pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ export const App: React.FC = () => {
 | `delayRegistrationUntilContactKeyIsSet`       | boolean | No       | Sets the configuration value which enables or disables application control over delaying SDK registration until a contact key is set                |
 | `markNotificationReadOnInboxNotificationOpen` | boolean | No       | Sets the configuration value which enables or disables marking inbox notifications as read on open                                   |
 | `debug`                                       | boolean | No       | Enable logging debug messages                                                                                                                       |
+| `shouldCreateServiceExtension`                | boolean | No       | Creates the notification service extension to enable rich push notifications for iOS                                                                |
+| `iosNseBundleIdSuffix`                        | string  | No       | Sets the suffix of the notification service extension ios bundleId                                                                                  |
+| `iosDevTeamId`                                | string  | No*      | This is the teamID on developer.apple.com. Used to enabling signing of the bundle. Required if creating an extension                                |
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ export const App: React.FC = () => {
 | `debug`                                       | boolean | No       | Enable logging debug messages                                                                                                                       |
 | `shouldCreateServiceExtension`                | boolean | No       | Creates the notification service extension to enable rich push notifications for iOS                                                                |
 | `iosNseBundleIdSuffix`                        | string  | No       | Sets the suffix of the notification service extension ios bundleId                                                                                  |
-| `iosDevTeamId`                                | string  | No*      | This is the teamID on developer.apple.com. Used to enabling signing of the bundle. Required if creating an extension                                |
+| `iosDevTeamId`                                | string  | No*      | This is the Team ID on developer.apple.com. It is used to sign the bundle. Required if creating an extension                                |
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
+    "prepare": "expo-module prepare && cp -a plugin/src/support/extension-files plugin/build/support/extension-files",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },

--- a/plugin/src/ios/index.ts
+++ b/plugin/src/ios/index.ts
@@ -29,7 +29,7 @@ export const withIOSConfig: ConfigPlugin<MarketingCloudSdkPluginValidProps> = (
     config = withXcodeProjectExtension(config, props);
     config = withEasManagedCredentials(config, props);
   } else if (props.shouldCreateServiceExtension) {
-    console.warn('iosDevTeamId is required when shouldCreateServiceExtension is true. Extension not created.');
+    console.warn('[expo-marketingcloudsdk] iosDevTeamId is required when shouldCreateServiceExtension is true. Extension not created.');
   }
   return config;
 };

--- a/plugin/src/ios/index.ts
+++ b/plugin/src/ios/index.ts
@@ -1,9 +1,20 @@
 import {
   ConfigPlugin,
   withInfoPlist,
+  withDangerousMod,
+  withXcodeProject,
 } from '@expo/config-plugins';
 
 import { MarketingCloudSdkPluginValidProps } from '../types';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { FileManager } from '../support/FileManager';
+import NseUpdaterManager from '../support/NseUpdaterManager';
+import { NSE_EXT_FILES, NSE_TARGET_NAME, TARGETED_DEVICE_FAMILY } from '../support/iosConstants';
+
+import getEasManagedCredentialsConfigExtra from '../support/eas/getEasManagedCredentialsConfigExtra';
+import { ExpoConfig } from '@expo/config-types';
 
 export const withIOSConfig: ConfigPlugin<MarketingCloudSdkPluginValidProps> = (
   config,
@@ -11,7 +22,11 @@ export const withIOSConfig: ConfigPlugin<MarketingCloudSdkPluginValidProps> = (
 ) => {
   config = withInfo(config, props)
   config = withRemoteNotificationsBackgroundMode(config, props)
-
+  if (props.shouldCreateServiceExtension) {
+    config = withServiceExtension(config, props);
+    config = withXcodeProjectExtension(config, props);
+    config = withEasManagedCredentials(config, props);
+  }
   return config;
 };
 
@@ -44,4 +59,114 @@ const withRemoteNotificationsBackgroundMode: ConfigPlugin<MarketingCloudSdkPlugi
   });
 
   return config;
-}
+};
+
+const withServiceExtension: ConfigPlugin<MarketingCloudSdkPluginValidProps> = (config, props) => {
+  const pluginDir = require.resolve('@allboatsrise/expo-marketingcloudsdk/package.json');
+  const sourceDir = path.join(pluginDir, '../plugin/src/support/extension-files/');
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      const iosPath = path.join(config.modRequest.projectRoot, 'ios');
+
+      fs.mkdirSync(`${iosPath}/${NSE_TARGET_NAME}`, {recursive: true});
+
+      for (let i = 0; i < NSE_EXT_FILES.length; i++) {
+        const extFile = NSE_EXT_FILES[i];
+        const targetFile = `${iosPath}/${NSE_TARGET_NAME}/${extFile}`;
+        await FileManager.copyFile(`${sourceDir}${extFile}`, targetFile);
+      }
+
+      const nseUpdater = new NseUpdaterManager(iosPath);
+      await nseUpdater.updateNSEBundleVersion(config.ios?.buildNumber ?? '1');
+      await nseUpdater.updateNSEBundleShortVersion(config?.version ?? '1.0.0');
+
+      return config;
+    },
+  ]);
+};
+
+const withXcodeProjectExtension: ConfigPlugin<MarketingCloudSdkPluginValidProps> = (
+  config,
+  props,
+) => {
+  return withXcodeProject(config, newConfig => {
+    const xcodeProject = newConfig.modResults;
+
+    if (xcodeProject.pbxTargetByName(NSE_TARGET_NAME)) {
+      return newConfig;
+    }
+
+    // Create new PBXGroup for the extension
+    const extGroup = xcodeProject.addPbxGroup([...NSE_EXT_FILES], NSE_TARGET_NAME, NSE_TARGET_NAME);
+
+    // Add the new PBXGroup to the top level group. This makes the
+    // files / folder appear in the file explorer in Xcode.
+    const groups = xcodeProject.hash.project.objects['PBXGroup'];
+    Object.keys(groups).forEach(function (key) {
+      if (
+        typeof groups[key] === 'object' &&
+        groups[key].name === undefined &&
+        groups[key].path === undefined
+      ) {
+        xcodeProject.addToPbxGroup(extGroup.uuid, key);
+      }
+    });
+
+    // WORK AROUND for codeProject.addTarget BUG
+    // Xcode projects don't contain these if there is only one target
+    // An upstream fix should be made to the code referenced in this link:
+    //   - https://github.com/apache/cordova-node-xcode/blob/8b98cabc5978359db88dc9ff2d4c015cba40f150/lib/pbxProject.js#L860
+    const projObjects = xcodeProject.hash.project.objects;
+    projObjects['PBXTargetDependency'] = projObjects['PBXTargetDependency'] || {};
+    projObjects['PBXContainerItemProxy'] = projObjects['PBXTargetDependency'] || {};
+
+    // Add the NSE target
+    // This adds PBXTargetDependency and PBXContainerItemProxy for you
+    const nseTarget = xcodeProject.addTarget(
+      NSE_TARGET_NAME,
+      'app_extension',
+      NSE_TARGET_NAME,
+      `${config.ios?.bundleIdentifier}.${props.iosNseBundleIdSuffix ?? NSE_TARGET_NAME}`,
+    );
+
+    // Add build phases to the new target
+    xcodeProject.addBuildPhase(
+      ['NotificationService.swift'],
+      'PBXSourcesBuildPhase',
+      'Sources',
+      nseTarget.uuid,
+    );
+
+    xcodeProject.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', nseTarget.uuid);
+    xcodeProject.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', nseTarget.uuid);
+
+    const configurations = xcodeProject.pbxXCBuildConfigurationSection();
+    for (const key in configurations) {
+      if (
+        typeof configurations[key].buildSettings !== 'undefined' &&
+        configurations[key].buildSettings.PRODUCT_NAME === `"${NSE_TARGET_NAME}"`
+      ) {
+        const buildSettingsObj = configurations[key].buildSettings;
+        buildSettingsObj.SWIFT_VERSION = '5.4';
+        buildSettingsObj.DEVELOPMENT_TEAM = props?.iosDevTeamId;
+        buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
+        buildSettingsObj.CODE_SIGN_STYLE = 'Automatic';
+      }
+    }
+    xcodeProject.addTargetAttribute('DevelopmentTeam', props?.iosDevTeamId, nseTarget);
+    xcodeProject.addTargetAttribute('DevelopmentTeam', props?.iosDevTeamId);
+    return newConfig;
+  });
+};
+
+const withEasManagedCredentials: ConfigPlugin<MarketingCloudSdkPluginValidProps> = (
+  config,
+  props,
+) => {
+  config.extra = getEasManagedCredentialsConfigExtra(
+    config as ExpoConfig,
+    props?.iosNseBundleIdSuffix,
+  );
+  return config;
+};

--- a/plugin/src/ios/index.ts
+++ b/plugin/src/ios/index.ts
@@ -79,7 +79,6 @@ const withServiceExtension: ConfigPlugin<MarketingCloudSdkPluginValidProps> = (c
         const targetFile = `${iosPath}/${targetName}/${extFile}`;
         await FileManager.copyFile(`${sourceDir}${extFile}`, targetFile);
       }
-      console.log('version numbers', config.ios?.buildNumber, config?.version);
       const nseUpdater = new NseUpdaterManager({iosPath, targetName, plistFileName: `${targetName}-Info.plist`});
       await nseUpdater.updateNSEBundleVersion(config.ios?.buildNumber ?? '1');
       await nseUpdater.updateNSEBundleShortVersion(config?.version ?? '1.0.0');

--- a/plugin/src/support/FileManager.ts
+++ b/plugin/src/support/FileManager.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+
+/**
+ * FileManager contains static *awaitable* file-system functions
+ */
+export class FileManager {
+  static async readFile(path: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      fs.readFile(path, 'utf8', (err, data) => {
+        if (err || !data) {
+          reject(err);
+          return;
+        }
+        resolve(data);
+      });
+    });
+  }
+
+  static async writeFile(path: string, contents: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      fs.writeFile(path, contents, 'utf8', err => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  static async copyFile(path1: string, path2: string): Promise<void> {
+    const fileContents = await FileManager.readFile(path1);
+    await FileManager.writeFile(path2, fileContents);
+  }
+
+  static dirExists(path: string): boolean {
+    return fs.existsSync(path);
+  }
+}

--- a/plugin/src/support/NseUpdaterManager.ts
+++ b/plugin/src/support/NseUpdaterManager.ts
@@ -1,0 +1,29 @@
+import {FileManager} from './FileManager';
+import {
+  BUNDLE_SHORT_VERSION_TEMPLATE_REGEX,
+  BUNDLE_VERSION_TEMPLATE_REGEX,
+  NSE_TARGET_NAME,
+} from './iosConstants';
+
+const plistFileName = `ExpoMarketingCloudSdkNSE-Info.plist`;
+
+export default class NseUpdaterManager {
+  private nsePath = '';
+  constructor(iosPath: string) {
+    this.nsePath = `${iosPath}/${NSE_TARGET_NAME}`;
+  }
+
+  async updateNSEBundleVersion(version: string): Promise<void> {
+    const plistFilePath = `${this.nsePath}/${plistFileName}`;
+    let plistFile = await FileManager.readFile(plistFilePath);
+    plistFile = plistFile.replace(BUNDLE_VERSION_TEMPLATE_REGEX, version);
+    await FileManager.writeFile(plistFilePath, plistFile);
+  }
+
+  async updateNSEBundleShortVersion(version: string): Promise<void> {
+    const plistFilePath = `${this.nsePath}/${plistFileName}`;
+    let plistFile = await FileManager.readFile(plistFilePath);
+    plistFile = plistFile.replace(BUNDLE_SHORT_VERSION_TEMPLATE_REGEX, version);
+    await FileManager.writeFile(plistFilePath, plistFile);
+  }
+}

--- a/plugin/src/support/NseUpdaterManager.ts
+++ b/plugin/src/support/NseUpdaterManager.ts
@@ -1,29 +1,28 @@
 import {FileManager} from './FileManager';
-import {
-  BUNDLE_SHORT_VERSION_TEMPLATE_REGEX,
-  BUNDLE_VERSION_TEMPLATE_REGEX,
-  NSE_TARGET_NAME,
-} from './iosConstants';
-
-const plistFileName = `ExpoMarketingCloudSdkNSE-Info.plist`;
-
+interface Params {
+  iosPath: string;
+  targetName: string;
+  plistFileName: string;
+}
 export default class NseUpdaterManager {
   private nsePath = '';
-  constructor(iosPath: string) {
-    this.nsePath = `${iosPath}/${NSE_TARGET_NAME}`;
+  private plistFileName = '';
+  constructor({iosPath, targetName, plistFileName}: Params) {
+    this.nsePath = `${iosPath}/${targetName}`;
+    this.plistFileName = plistFileName;
   }
 
   async updateNSEBundleVersion(version: string): Promise<void> {
-    const plistFilePath = `${this.nsePath}/${plistFileName}`;
+    const plistFilePath = `${this.nsePath}/${this.plistFileName}`;
     let plistFile = await FileManager.readFile(plistFilePath);
-    plistFile = plistFile.replace(BUNDLE_VERSION_TEMPLATE_REGEX, version);
+    plistFile = plistFile.replace(/{{BUNDLE_VERSION}}/g, version);
     await FileManager.writeFile(plistFilePath, plistFile);
   }
 
   async updateNSEBundleShortVersion(version: string): Promise<void> {
-    const plistFilePath = `${this.nsePath}/${plistFileName}`;
+    const plistFilePath = `${this.nsePath}/${this.plistFileName}`;
     let plistFile = await FileManager.readFile(plistFilePath);
-    plistFile = plistFile.replace(BUNDLE_SHORT_VERSION_TEMPLATE_REGEX, version);
+    plistFile = plistFile.replace(/{{BUNDLE_SHORT_VERSION}}/g, version);
     await FileManager.writeFile(plistFilePath, plistFile);
   }
 }

--- a/plugin/src/support/eas/getEasManagedCredentialsConfigExtra.ts
+++ b/plugin/src/support/eas/getEasManagedCredentialsConfigExtra.ts
@@ -1,11 +1,12 @@
 import {ExpoConfig} from '@expo/config-types';
 
-import {NSE_TARGET_NAME} from '../iosConstants';
+interface Params {
+  config: ExpoConfig;
+  targetName: string;
+  bundleSuffix?: string;
+}
 
-export default function getEasManagedCredentialsConfigExtra(
-  config: ExpoConfig,
-  bundleSuffix?: String,
-): {
+export default function getEasManagedCredentialsConfigExtra({ config, targetName, bundleSuffix}: Params): {
   [k: string]: any;
 } {
   return {
@@ -22,9 +23,9 @@ export default function getEasManagedCredentialsConfigExtra(
               ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
               {
                 // keep in sync with native changes in NSE
-                targetName: NSE_TARGET_NAME,
+                targetName: targetName,
                 bundleIdentifier: `${config?.ios?.bundleIdentifier}.${
-                  bundleSuffix ?? NSE_TARGET_NAME
+                  bundleSuffix ?? targetName
                 }`,
               },
             ],

--- a/plugin/src/support/eas/getEasManagedCredentialsConfigExtra.ts
+++ b/plugin/src/support/eas/getEasManagedCredentialsConfigExtra.ts
@@ -1,0 +1,36 @@
+import {ExpoConfig} from '@expo/config-types';
+
+import {NSE_TARGET_NAME} from '../iosConstants';
+
+export default function getEasManagedCredentialsConfigExtra(
+  config: ExpoConfig,
+  bundleSuffix?: String,
+): {
+  [k: string]: any;
+} {
+  return {
+    ...config.extra,
+    eas: {
+      ...config.extra?.eas,
+      build: {
+        ...config.extra?.eas?.build,
+        experimental: {
+          ...config.extra?.eas?.build?.experimental,
+          ios: {
+            ...config.extra?.eas?.build?.experimental?.ios,
+            appExtensions: [
+              ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
+              {
+                // keep in sync with native changes in NSE
+                targetName: NSE_TARGET_NAME,
+                bundleIdentifier: `${config?.ios?.bundleIdentifier}.${
+                  bundleSuffix ?? NSE_TARGET_NAME
+                }`,
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+}

--- a/plugin/src/support/extension-files/ExpoMarketingCloudSdkNSE-Info.plist
+++ b/plugin/src/support/extension-files/ExpoMarketingCloudSdkNSE-Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ExpoMarketingCloudSdkNSE</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>{{BUNDLE_SHORT_VERSION}}</string>
+	<key>CFBundleVersion</key>
+	<string>{{BUNDLE_VERSION}}</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/plugin/src/support/extension-files/NotificationService.swift
+++ b/plugin/src/support/extension-files/NotificationService.swift
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import CoreGraphics
+import UserNotifications
+
+class NotificationService: UNNotificationServiceExtension {
+    var contentHandler: ((_ contentToDeliver: UNNotificationContent) -> Void)? = nil
+    var modifiedNotificationContent: UNMutableNotificationContent?
+
+    func createMediaAttachment(_ localMediaUrl: URL) -> UNNotificationAttachment {
+        // options: specify what cropping rectangle of the media to use for a thumbnail
+        //          whether the thumbnail is hidden or not
+        let clippingRect = CGRect.zero
+        let mediaAttachment = try? UNNotificationAttachment(identifier: "attachmentIdentifier", url: localMediaUrl, options: [UNNotificationAttachmentOptionsThumbnailClippingRectKey: clippingRect.dictionaryRepresentation, UNNotificationAttachmentOptionsThumbnailHiddenKey: false])
+        return mediaAttachment!
+    }
+
+    override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+
+        // save the completion handler we will call back later
+        self.contentHandler = contentHandler
+
+        // make a copy of the notification so we can change it
+        modifiedNotificationContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
+
+        // does the payload contains a remote URL to download or a local URL?
+        if let mediaUrlString = request.content.userInfo["_mediaUrl"] as? String {
+            // see if the media URL is for a local file  (i.e., file://movie.mp4)
+            guard let mediaUrl = URL(string: mediaUrlString) else {
+                // attempt to create a URL to a file in local storage
+                var useAlternateText: Bool = true
+                if mediaUrlString.isEmpty == false {
+                    let mediaUrlFilename:NSString = mediaUrlString as NSString
+                    let fileName = (mediaUrlFilename.lastPathComponent as NSString).deletingPathExtension
+                    let fileExtension = (mediaUrlFilename.lastPathComponent as NSString).pathExtension
+
+                    // is it in the bundle?
+                    if let localMediaUrlPath = Bundle.main.path(forResource: fileName, ofType: fileExtension) {
+                        // is the URL a local file URL?
+                        let localMediaUrl = URL.init(fileURLWithPath: localMediaUrlPath)
+                        if localMediaUrl.isFileURL == true {
+                            // create an attachment with the local media
+                            let mediaAttachment: UNNotificationAttachment? = createMediaAttachment(localMediaUrl)
+
+                            // if no problems creating the attachment, we can use it
+                            if mediaAttachment != nil {
+                                // set the media to display in the notification
+                                modifiedNotificationContent?.attachments = [mediaAttachment!]
+
+                                // everything is ok
+                                useAlternateText = false
+                            }
+                        }
+                    }
+                }
+
+                // if any problems creating the attachment, use the alternate text if provided
+                if (useAlternateText == true) {
+                    if let mediaAltText = request.content.userInfo["_mediaAlt"] as? String {
+                        if mediaAltText.isEmpty == false {
+                            modifiedNotificationContent?.body = mediaAltText
+                        }
+                    }
+                }
+
+                // tell the OS we are done and here is the new content
+                contentHandler(modifiedNotificationContent!)
+                return
+            }
+
+            // if we have a URL, try to download media (i.e., https://media.giphy.com/media/3oz8xJBbCpzG9byZmU/giphy.gif)
+            if mediaUrl.isFileURL == false {
+                // create a session to handle downloading of the URL
+                let session = URLSession(configuration: URLSessionConfiguration.default)
+
+                // start a download task to handle the download of the media
+                weak var weakSelf: NotificationService? = self
+                session.downloadTask(with: mediaUrl, completionHandler: {(_ location: URL?, _ response: URLResponse?, _ error: Error?) -> Void in
+                    var useAlternateText: Bool = true
+                    // if the download succeeded, save it locally and then make an attachment
+                    if error == nil {
+                        let downloadResponse = response as! HTTPURLResponse
+                        if (downloadResponse.statusCode >= 200 && downloadResponse.statusCode <= 299) {
+                            // download was successful, attempt save the media file
+                            let localMediaUrl = URL.init(fileURLWithPath: location!.path + mediaUrl.lastPathComponent)
+
+                            // remove any existing file with the same name
+                            try? FileManager.default.removeItem(at: localMediaUrl)
+
+                            // move the downloaded file from the temporary location to a new file
+                            if ((try? FileManager.default.moveItem(at: location!, to: localMediaUrl)) != nil) {
+                                // create an attachment with the new file
+                                let mediaAttachment: UNNotificationAttachment? = weakSelf?.createMediaAttachment(localMediaUrl)
+
+                                // if no problems creating the attachment, we can use it
+                                if mediaAttachment != nil {
+                                    // set the media to display in the notification
+                                    weakSelf?.modifiedNotificationContent?.attachments = [mediaAttachment!]
+
+                                    // everything is ok
+                                    useAlternateText = false
+                                }
+                            }
+                        }
+                    }
+
+                    // if any problems creating the attachment, use the alternate text if provided
+                    // alternative text to display if there are any issues loading the media URL
+                    if (useAlternateText == true) {
+                        if let mediaAltText = request.content.userInfo["_mediaAlt"] as? String {
+                            if mediaAltText.isEmpty == false {
+                                weakSelf?.modifiedNotificationContent?.body = mediaAltText
+                            }
+                        }
+                    }
+
+                    // tell the OS we are done and here is the new content
+                    weakSelf?.contentHandler!((weakSelf?.modifiedNotificationContent)!)
+                }).resume()
+            }
+        }
+        else {
+            // no media URL found in the payload, just pass on the orginal payload
+            contentHandler(request.content)
+            return
+        }
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        // Called just before the extension will be terminated by the system.
+        // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
+        // we took too long to download the media URL, use the alternate text if provided
+        if let mediaAltText = modifiedNotificationContent?.userInfo["_mediaAlt"] as? String {
+            // alternative text to display if there are any issues loading the media URL
+            if mediaAltText.isEmpty == false {
+                modifiedNotificationContent?.body = mediaAltText
+            }
+        }
+
+        // tell the OS we are done and here is the new content
+        contentHandler!(modifiedNotificationContent!)
+    }
+}

--- a/plugin/src/support/iosConstants.ts
+++ b/plugin/src/support/iosConstants.ts
@@ -1,0 +1,7 @@
+export const TARGETED_DEVICE_FAMILY = `"1,2"`;
+
+export const BUNDLE_SHORT_VERSION_TEMPLATE_REGEX = /{{BUNDLE_SHORT_VERSION}}/gm;
+export const BUNDLE_VERSION_TEMPLATE_REGEX = /{{BUNDLE_VERSION}}/gm;
+
+export const NSE_TARGET_NAME = 'ExpoMarketingCloudSdkNSE';
+export const NSE_EXT_FILES = ['NotificationService.swift', `${NSE_TARGET_NAME}-Info.plist`];

--- a/plugin/src/support/iosConstants.ts
+++ b/plugin/src/support/iosConstants.ts
@@ -1,7 +1,0 @@
-export const TARGETED_DEVICE_FAMILY = `"1,2"`;
-
-export const BUNDLE_SHORT_VERSION_TEMPLATE_REGEX = /{{BUNDLE_SHORT_VERSION}}/gm;
-export const BUNDLE_VERSION_TEMPLATE_REGEX = /{{BUNDLE_VERSION}}/gm;
-
-export const NSE_TARGET_NAME = 'ExpoMarketingCloudSdkNSE';
-export const NSE_EXT_FILES = ['NotificationService.swift', `${NSE_TARGET_NAME}-Info.plist`];

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -53,4 +53,19 @@ export const MarketingCloudSDKPluginPropsSchema = z.object({
   delayRegistrationUntilContactKeyIsSet: z.boolean().optional().default(false),
 
   markNotificationReadOnInboxNotificationOpen: z.boolean().optional().default(false),
+
+  /**
+   * Makes an iOS Notification Service extension to enable rich media push notificaitons.
+   */
+  shouldCreateServiceExtension: z.boolean().optional().default(false),
+
+  /**
+     * Sets the value of the ios notification service extension (NSE). This is appened to the bundle identifier of the app. If not set the default value is `NotificationService`.
+     */
+  iosNseBundleIdSuffix: z.string().min(1).optional().default('NotificationService'),
+
+  /**
+   * Sets the value of the ios notification service extension (NSE) target dev team. Requered if `shouldCreateServiceExtension` is true.
+   */
+  iosDevTeamId: z.string().min(1).optional(),
 }, {required_error: 'Must configure plugin options.'})


### PR DESCRIPTION
This address feature request #41 

Allows a user to optionally creates a notification service extension when running expo prebuild to enable [Rich Notifications](https://developer.salesforce.com/docs/marketing/mobilepush/guide/customize-push-notifications-ios.html#send-rich-notifications)

