### PR TITLE
feat: enable/disable analytics programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Various functions, their parameters, return values, and their specific purposes 
 | `getReadMessageCount` | None | `Promise<number>` | Returns a promise that resolves to a number representing the total number of read inbox messages. |
 | `getReadMessages` | None | `Promise<InboxMessage[]>` | Returns a promise that resolves to an array of `InboxMessage` objects representing the read inbox messages. |
 | `trackMessageOpened` | `messageId`: string | Promise<boolean> | Returns a promise that resolves to true when inbox open event successfully triggered on message. |
+| `isAnalyticsEnabled` | None | Returns a promise that resolves to a boolean indicating whether analytics are enabled for the user. |
+| `enableAnalytics` | None | `Promise<void>` | Returns a promise that resolves when analytics have been successfully enabled. |
+| `disableAnalytics` | None | `Promise<void>` | Returns a promise that resolves when analytics have been successfully disabled. |
 
 
 ## Add event listener

--- a/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
+++ b/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
@@ -197,7 +197,7 @@ class ExpoMarketingCloudSdkModule : Module() {
     AsyncFunction("enableAnalytics") { promise: Promise ->
       whenPushModuleReady(promise) { mp ->
         mp.analyticsManager.enableAnalytics()
-        promise.resolve(mp.analyticsManager.enableAnalytics())
+        promise.resolve(mp.analyticsManager.areAnalyticsEnabled())
       }
     }
 

--- a/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
+++ b/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
@@ -190,6 +190,24 @@ class ExpoMarketingCloudSdkModule : Module() {
       }
     }
 
+    AsyncFunction("isAnalyticsEnabled") { promise: Promise ->
+      whenPushModuleReady(promise) { mp -> promise.resolve(mp.analyticsManager.areAnalyticsEnabled()) }
+    }
+
+    AsyncFunction("enableAnalytics") { promise: Promise ->
+      whenPushModuleReady(promise) { mp ->
+        mp.analyticsManager.enableAnalytics()
+        promise.resolve(mp.analyticsManager.enableAnalytics())
+      }
+    }
+
+    AsyncFunction("disableAnalytics") { promise: Promise ->
+      whenPushModuleReady(promise) { mp ->
+        mp.analyticsManager.disableAnalytics()
+        promise.resolve(mp.analyticsManager.areAnalyticsEnabled())
+      }
+    }
+
     AsyncFunction("startObserving") {eventName: String? ->
       when (eventName) {
         "onLog" -> {

--- a/ios/ExpoMarketingCloudSdkModule.swift
+++ b/ios/ExpoMarketingCloudSdkModule.swift
@@ -274,6 +274,27 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
         }
       }
     }
+
+    AsyncFunction("isAnalyticsEnabled") { (promise: Promise) in
+      SFMCSdk.requestPushSdk { mp in
+        promise.resolve(mp.isAnalyticsEnabled())
+      }
+    }
+
+    AsyncFunction("enableAnalytics") { (promise: Promise) in
+      SFMCSdk.requestPushSdk { mp in
+        mp.setAnalyticsEnabled(true)
+        promise.resolve(mp.isAnalyticsEnabled())
+      }
+    }
+
+    AsyncFunction("disableAnalytics") { (promise: Promise) in
+      SFMCSdk.requestPushSdk { mp in
+        mp.setAnalyticsEnabled(false)
+        promise.resolve(mp.isAnalyticsEnabled())
+      }
+    }
+
   }
   
   @objc

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,16 @@
-import { NativeModulesProxy, EventEmitter, Subscription } from 'expo-modules-core';
+import {
+  NativeModulesProxy,
+  EventEmitter,
+  Subscription,
+} from "expo-modules-core";
 
-import ExpoMarketingCloudSdkModule from './ExpoMarketingCloudSdkModule';
-import { InboxResponsePayload, LogEventPayload, InboxMessage, RegistrationResponseSucceededPayload } from './ExpoMarketingCloudSdk.types';
+import ExpoMarketingCloudSdkModule from "./ExpoMarketingCloudSdkModule";
+import {
+  InboxResponsePayload,
+  LogEventPayload,
+  InboxMessage,
+  RegistrationResponseSucceededPayload,
+} from "./ExpoMarketingCloudSdk.types";
 
 export async function isPushEnabled(): Promise<boolean> {
   return await ExpoMarketingCloudSdkModule.isPushEnabled();
@@ -31,11 +40,16 @@ export async function getAttributes(): Promise<Record<string, string> | null> {
   return await ExpoMarketingCloudSdkModule.getAttributes();
 }
 
-export async function setAttribute(key: string, value: string): Promise<Record<string, string> | null> {
+export async function setAttribute(
+  key: string,
+  value: string
+): Promise<Record<string, string> | null> {
   return await ExpoMarketingCloudSdkModule.setAttribute(key, value);
 }
 
-export async function clearAttribute(key: string): Promise<Record<string, string> | null> {
+export async function clearAttribute(
+  key: string
+): Promise<Record<string, string> | null> {
   return await ExpoMarketingCloudSdkModule.clearAttribute(key);
 }
 
@@ -51,7 +65,9 @@ export async function getTags(): Promise<string[] | null> {
   return await ExpoMarketingCloudSdkModule.getTags();
 }
 
-export async function setContactKey(contactKey: string): Promise<string | null> {
+export async function setContactKey(
+  contactKey: string
+): Promise<string | null> {
   return await ExpoMarketingCloudSdkModule.setContactKey(contactKey);
 }
 
@@ -63,7 +79,10 @@ export async function getSdkState(): Promise<string> {
   return await ExpoMarketingCloudSdkModule.getSdkState();
 }
 
-export async function track(name: string, attributes: Record<string, string>): Promise<true> {
+export async function track(
+  name: string,
+  attributes: Record<string, string>
+): Promise<true> {
   return await ExpoMarketingCloudSdkModule.track(name, attributes);
 }
 
@@ -123,19 +142,46 @@ export async function trackMessageOpened(messageId: string): Promise<boolean> {
   return await ExpoMarketingCloudSdkModule.trackMessageOpened(messageId);
 }
 
-
-const emitter = new EventEmitter(ExpoMarketingCloudSdkModule ?? NativeModulesProxy.ExpoMarketingCloudSdk);
-
-export function addLogListener(listener: (event: LogEventPayload) => void): Subscription {
-  return emitter.addListener<LogEventPayload>('onLog', listener);
+export async function isAnalyticsEnabled(): Promise<boolean> {
+  return await ExpoMarketingCloudSdkModule.isAnalyticsEnabled();
 }
 
-export function addInboxResponseListener(listener: (event: InboxResponsePayload) => void): Subscription {
-  return emitter.addListener<InboxResponsePayload>('onInboxResponse', listener)
+export async function enableAnalytics(): Promise<boolean> {
+  return await ExpoMarketingCloudSdkModule.enableAnalytics();
 }
 
-export function addRegistrationResponseSucceededListener(listener: (event: RegistrationResponseSucceededPayload) => void): Subscription {
-  return emitter.addListener<RegistrationResponseSucceededPayload>('onRegistrationResponseSucceeded', listener)
+export async function disableAnalytics(): Promise<boolean> {
+  return await ExpoMarketingCloudSdkModule.disableAnalytics();
 }
 
-export { LogEventPayload, InboxResponsePayload, InboxMessage, RegistrationResponseSucceededPayload }
+const emitter = new EventEmitter(
+  ExpoMarketingCloudSdkModule ?? NativeModulesProxy.ExpoMarketingCloudSdk
+);
+
+export function addLogListener(
+  listener: (event: LogEventPayload) => void
+): Subscription {
+  return emitter.addListener<LogEventPayload>("onLog", listener);
+}
+
+export function addInboxResponseListener(
+  listener: (event: InboxResponsePayload) => void
+): Subscription {
+  return emitter.addListener<InboxResponsePayload>("onInboxResponse", listener);
+}
+
+export function addRegistrationResponseSucceededListener(
+  listener: (event: RegistrationResponseSucceededPayload) => void
+): Subscription {
+  return emitter.addListener<RegistrationResponseSucceededPayload>(
+    "onRegistrationResponseSucceeded",
+    listener
+  );
+}
+
+export {
+  LogEventPayload,
+  InboxResponsePayload,
+  InboxMessage,
+  RegistrationResponseSucceededPayload,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,12 @@
-import {
-  NativeModulesProxy,
-  EventEmitter,
-  Subscription,
-} from "expo-modules-core";
+import { NativeModulesProxy, EventEmitter, Subscription } from 'expo-modules-core';
 
-import ExpoMarketingCloudSdkModule from "./ExpoMarketingCloudSdkModule";
+import ExpoMarketingCloudSdkModule from './ExpoMarketingCloudSdkModule';
 import {
   InboxResponsePayload,
   LogEventPayload,
   InboxMessage,
   RegistrationResponseSucceededPayload,
-} from "./ExpoMarketingCloudSdk.types";
+} from './ExpoMarketingCloudSdk.types';
 
 export async function isPushEnabled(): Promise<boolean> {
   return await ExpoMarketingCloudSdkModule.isPushEnabled();
@@ -40,16 +36,11 @@ export async function getAttributes(): Promise<Record<string, string> | null> {
   return await ExpoMarketingCloudSdkModule.getAttributes();
 }
 
-export async function setAttribute(
-  key: string,
-  value: string
-): Promise<Record<string, string> | null> {
+export async function setAttribute(key: string, value: string): Promise<Record<string, string> | null> {
   return await ExpoMarketingCloudSdkModule.setAttribute(key, value);
 }
 
-export async function clearAttribute(
-  key: string
-): Promise<Record<string, string> | null> {
+export async function clearAttribute(key: string): Promise<Record<string, string> | null> {
   return await ExpoMarketingCloudSdkModule.clearAttribute(key);
 }
 
@@ -65,9 +56,7 @@ export async function getTags(): Promise<string[] | null> {
   return await ExpoMarketingCloudSdkModule.getTags();
 }
 
-export async function setContactKey(
-  contactKey: string
-): Promise<string | null> {
+export async function setContactKey(contactKey: string): Promise<string | null> {
   return await ExpoMarketingCloudSdkModule.setContactKey(contactKey);
 }
 
@@ -79,10 +68,7 @@ export async function getSdkState(): Promise<string> {
   return await ExpoMarketingCloudSdkModule.getSdkState();
 }
 
-export async function track(
-  name: string,
-  attributes: Record<string, string>
-): Promise<true> {
+export async function track(name: string, attributes: Record<string, string>): Promise<true> {
   return await ExpoMarketingCloudSdkModule.track(name, attributes);
 }
 
@@ -154,34 +140,20 @@ export async function disableAnalytics(): Promise<boolean> {
   return await ExpoMarketingCloudSdkModule.disableAnalytics();
 }
 
-const emitter = new EventEmitter(
-  ExpoMarketingCloudSdkModule ?? NativeModulesProxy.ExpoMarketingCloudSdk
-);
+const emitter = new EventEmitter(ExpoMarketingCloudSdkModule ?? NativeModulesProxy.ExpoMarketingCloudSdk);
 
-export function addLogListener(
-  listener: (event: LogEventPayload) => void
-): Subscription {
-  return emitter.addListener<LogEventPayload>("onLog", listener);
+export function addLogListener(listener: (event: LogEventPayload) => void): Subscription {
+  return emitter.addListener<LogEventPayload>('onLog', listener);
 }
 
-export function addInboxResponseListener(
-  listener: (event: InboxResponsePayload) => void
-): Subscription {
-  return emitter.addListener<InboxResponsePayload>("onInboxResponse", listener);
+export function addInboxResponseListener(listener: (event: InboxResponsePayload) => void): Subscription {
+  return emitter.addListener<InboxResponsePayload>('onInboxResponse', listener);
 }
 
 export function addRegistrationResponseSucceededListener(
   listener: (event: RegistrationResponseSucceededPayload) => void
 ): Subscription {
-  return emitter.addListener<RegistrationResponseSucceededPayload>(
-    "onRegistrationResponseSucceeded",
-    listener
-  );
+  return emitter.addListener<RegistrationResponseSucceededPayload>('onRegistrationResponseSucceeded', listener);
 }
 
-export {
-  LogEventPayload,
-  InboxResponsePayload,
-  InboxMessage,
-  RegistrationResponseSucceededPayload,
-};
+export { LogEventPayload, InboxResponsePayload, InboxMessage, RegistrationResponseSucceededPayload };


### PR DESCRIPTION
This PR adds support for `isAnalytics`, `enableAnalytics`, and `disableAnalytics`, resolving #46. 

My local linter setup seems to have reformatted the code as there's no linter rules set for the repo. Please let me know if you want me to revert the formatting changes. 