### PR TITLE
feat: add Business Unit migration APIs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,39 @@ Various functions, their parameters, return values, and their specific purposes 
 | `isSfmcNotificationResponse` | Check if a notification response `NotificationResponse` originated from SFMC. |
 | `extractPayloadFromSfmcNotificationResponse` | Extract payload info from SFMC notification reponse. |
 | `useLastSfmcNotificationResponse` | A React hook that always returns the SFMC notification response that was received most recently. |
+| `migrateBu` | Migrates the SDK to a new Business Unit config at runtime while attempting to carry over existing state (contact key, attributes, tags, push token & enabled flag). Returns a `BuMigrationResponse`. |
+| `getStoredBu` | Returns the last stored Business Unit override (`BuConfig`) or `null` if none. The `serverUrl` is normalized to include a trailing `/`. |
+| `clearStoredBu` | Clears any stored Business Unit override so that the next app start uses the static plugin configuration. |
+
+### Business Unit (BU) Migration
+
+Use `migrateBu({ appId, accessToken, serverUrl, mid? })` to switch the SDK to a different Business Unit at runtime. The operation:
+
+* Temporarily disables push (to force a registration cycle) before reconfiguring.
+* Reconfigures the native SDK with the new credentials.
+* Restores carried state: contact key, profile attributes, tags, push token & push enabled state (if previously enabled).
+* Persists the new BU so it is reused on next launch (`getStoredBu`).
+
+`BuMigrationResponse` shape:
+
+```
+{
+  success: boolean;
+  newAppId: string; // the appId provided
+  carried: {
+    contactKey: string | null | undefined;
+    attributeCount: number; // number of attributes carried over
+    tagCount: number;       // number of tags carried over
+    tokenCarried: boolean;  // true if the push token was successfully restored
+  };
+  isPushEnabled: boolean;   // final push enabled state after migration
+}
+```
+
+Notes:
+* `serverUrl` is always stored & returned with a trailing `/`.
+* Call `clearStoredBu()` to revert to the static plugin configuration (e.g., for sign-out flows).
+* If migration times out internally, it rejects with an `ERR_MIGRATION_TIMEOUT` error code.
 
 
 ## Add event listener

--- a/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkApplicationLifecycleListener.kt
+++ b/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkApplicationLifecycleListener.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
+import android.content.SharedPreferences
 import com.salesforce.marketingcloud.MCLogListener
 import com.salesforce.marketingcloud.MarketingCloudConfig
 import com.salesforce.marketingcloud.MarketingCloudSdk
@@ -20,6 +21,26 @@ import kotlin.random.Random
 
 
 class ExpoMarketingCloudSdkApplicationLifecycleListener : ApplicationLifecycleListener {
+
+  private data class StoredBuConfig(
+    val appId: String,
+    val accessToken: String,
+    val serverUrl: String,
+    val mid: String?
+  )
+
+  private fun prefs(context: Context): SharedPreferences = context.getSharedPreferences("expo_marketingcloudsdk_bu", Context.MODE_PRIVATE)
+
+  private fun loadStoredConfig(context: Context): StoredBuConfig? {
+    val p = prefs(context)
+  val appId = p.getString("storedAppId", null) ?: return null
+  val accessToken = p.getString("storedAccessToken", null) ?: return null
+  val serverUrlRaw = p.getString("storedServerUrl", null) ?: return null
+    val serverUrl = if (serverUrlRaw.endsWith('/')) serverUrlRaw else "$serverUrlRaw/"
+  val mid = p.getString("storedMid", null)?.takeIf { it.isNotBlank() }
+    return StoredBuConfig(appId, accessToken, serverUrl, mid)
+  }
+
   override fun onCreate(application: Application) {
     // Initialize logging _before_ initializing the SDK to avoid losing valuable debugging information.
     if(getDebug(application)) {
@@ -36,14 +57,18 @@ class ExpoMarketingCloudSdkApplicationLifecycleListener : ApplicationLifecycleLi
       }
     }
 
-    // Configure Salesforce Marketing Cloud SDK
+  // Prefer stored BU config (from previous migrateBu) over static plugin resources if present
+  val stored = loadStoredConfig(application)
+
+  // Configure Salesforce Marketing Cloud SDK
     SFMCSdk.configure(application, SFMCSdkModuleConfig.build {
       pushModuleConfig = MarketingCloudConfig.builder().apply {
-        setApplicationId(getAppId(application))
-        if(getMid(application) != "") setMid(getMid(application))
-        setAccessToken(getAccessToken(application))
-        setAnalyticsEnabled(getAnalyticsEnabled(application))
-        setMarketingCloudServerUrl(getServerUrl(application))
+    setApplicationId(stored?.appId ?: getAppId(application))
+    val mid = stored?.mid ?: getMid(application)
+    if(mid != "") setMid(mid)
+    setAccessToken(stored?.accessToken ?: getAccessToken(application))
+    setAnalyticsEnabled(getAnalyticsEnabled(application))
+  setMarketingCloudServerUrl(stored?.serverUrl ?: getServerUrl(application).let { if (it.endsWith('/')) it else "$it/" })
         setDelayRegistrationUntilContactKeyIsSet(getDelayRegistrationUntilContactKeyIsSet(application))
         if(getSenderId(application) != "") setSenderId(getSenderId(application))
         setInboxEnabled(getInboxEnabled(application))

--- a/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
+++ b/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
@@ -1,10 +1,14 @@
 package expo.modules.marketingcloudsdk
 
 import com.facebook.react.bridge.ReadableMap
+import android.util.Log
 import com.salesforce.marketingcloud.InitializationStatus
 import com.salesforce.marketingcloud.MCLogListener
 import com.salesforce.marketingcloud.MarketingCloudSdk
 import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk
+import com.salesforce.marketingcloud.notifications.NotificationCustomizationOptions
+import com.salesforce.marketingcloud.notifications.NotificationManager
+import com.salesforce.marketingcloud.notifications.NotificationMessage
 import com.salesforce.marketingcloud.sfmcsdk.components.events.EventManager
 import com.salesforce.marketingcloud.sfmcsdk.components.logging.LogLevel
 import com.salesforce.marketingcloud.sfmcsdk.components.logging.LogListener
@@ -18,12 +22,14 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.serialization.json.*
 import java.text.SimpleDateFormat
+import org.json.JSONObject
 
 
 class ExpoMarketingCloudSdkModule : Module() {
   private var defaultLogLevel : Int = MCLogListener.WARN
   private var inboxResponseListener : InboxResponseListener? = null
   private var registrationListener : RegistrationEventListener? = null
+  private var isMigratingBu: Boolean = false
 
   // Each module class must implement the definition function. The definition consists of components
   // that describes the module's functionality and behavior.
@@ -212,6 +218,294 @@ class ExpoMarketingCloudSdkModule : Module() {
       }
     }
 
+    AsyncFunction("migrateBu") { config: ReadableMap, promise: Promise ->
+      val newAppId = if (config.hasKey("appId")) config.getString("appId") else null
+      val newAccessToken = if (config.hasKey("accessToken")) config.getString("accessToken") else null
+      val newServerUrl = if (config.hasKey("serverUrl")) config.getString("serverUrl") else null
+      val newMid = if (config.hasKey("mid")) config.getString("mid") else null
+      // Internal self-contained timing constants
+      val MIGRATION_TIMEOUT_MS = 30_000
+      val FORCE_RECONFIGURE_MS = 8_000
+      val POLL_INTERVAL_MS = 2_000L
+      val REDISABLE_RETRY_MS = 3_000L
+      val MAX_REDISABLE_ATTEMPTS = 3
+      val TAG = "ExpoMCSdkMigration"
+
+  if (newAppId.isNullOrBlank() || newAccessToken.isNullOrBlank() || newServerUrl.isNullOrBlank()) {
+        promise.reject("ERR_INVALID_CONFIG", "appId, accessToken and serverUrl are required", null)
+        return@AsyncFunction
+      }
+      if (isMigratingBu) {
+        promise.reject("ERR_MIGRATION_IN_PROGRESS", "A BU migration is already in progress", null)
+        return@AsyncFunction
+      }
+  Log.d(TAG, "Starting BU migration -> newAppId=$newAppId serverUrl=$newServerUrl mid=$newMid")
+
+      whenPushModuleReady(promise) { mp ->
+        if (isMigratingBu) {
+          promise.reject("ERR_MIGRATION_IN_PROGRESS", "A BU migration is already in progress", null)
+          return@whenPushModuleReady
+        }
+        isMigratingBu = true
+        val savedAttributes = HashMap(mp.registrationManager.attributes)
+        val savedTags = HashSet(mp.registrationManager.tags)
+        val savedContactKey = mp.registrationManager.contactKey
+        val savedToken = mp.pushMessageManager.pushToken
+        val wasPushEnabled = mp.pushMessageManager.isPushEnabled
+        var previousSenderId: String? = null
+        var previousAppId: String? = null
+        SFMCSdk.requestSdk { sdk ->
+          try {
+            val state = sdk.getSdkState()
+            val pushObj: JSONObject? = state.optJSONObject("PUSH")
+            val initConfig = pushObj?.optJSONObject("initConfig")
+            previousSenderId = initConfig?.optString("senderId")?.takeIf { !it.isNullOrBlank() }
+            previousAppId = initConfig?.optString("applicationId")
+            Log.d(TAG, "Previous state: appId=$previousAppId senderId=$previousSenderId")
+          } catch (ex: Throwable) {
+            Log.w(TAG, "Failed parsing previous sdk state: ${ex.message}")
+          }
+        }
+        val normalizedServerUrl = newServerUrl?.let { if (it.endsWith('/')) it else "$it/" }
+        if (normalizedServerUrl == null) {
+          // Safety check
+          isMigratingBu = false
+          promise.reject("ERR_INVALID_CONFIG", "serverUrl missing", null)
+          return@whenPushModuleReady
+        }
+  var completed = false
+        val handler = android.os.Handler(android.os.Looper.getMainLooper())
+
+  // Will hold registration listener so reconfigure helper can unregister it
+  var tempListener: RegistrationEventListener? = null
+  // Track if reconfiguration has started to avoid duplicate calls
+  var startedReconfigure = false
+  // Forward declarations for runnables so we can remove them selectively
+  var pollRunnable: Runnable? = null
+  var timeoutRunnable: Runnable? = null
+  var reDisableRunnable: Runnable? = null
+  var reDisableAttempts = 0
+
+        // Helper to perform reconfiguration once push is disabled
+        fun reconfigureAndRestore(force: Boolean = false) {
+          if (completed || startedReconfigure) return
+          if (!force && mp.pushMessageManager.isPushEnabled) return
+          startedReconfigure = true
+          val senderIdSnapshot = previousSenderId
+          val contactKeySnapshot = savedContactKey
+          // stop further polling but keep timeout until success/failure
+          pollRunnable?.let { handler.removeCallbacks(it) }
+          try { tempListener?.let { mp.registrationManager.unregisterForRegistrationEvents(it) } } catch (_: Throwable) {}
+          reDisableRunnable?.let { handler.removeCallbacks(it) }
+          Log.d(TAG, "Reconfiguring SDK (force=$force) newAppId=$newAppId prevAppId=$previousAppId url=$normalizedServerUrl mid=$newMid prevSender=$senderIdSnapshot willDelay=${!contactKeySnapshot.isNullOrBlank()}")
+
+          SFMCSdk.configure(appContext.reactContext!!.applicationContext, com.salesforce.marketingcloud.sfmcsdk.SFMCSdkModuleConfig.build {
+            pushModuleConfig = com.salesforce.marketingcloud.MarketingCloudConfig.builder().apply {
+              setApplicationId(newAppId)
+              setAccessToken(newAccessToken)
+              normalizedServerUrl?.let { setMarketingCloudServerUrl(it) }
+              if (!newMid.isNullOrBlank()) setMid(newMid)
+              if (!senderIdSnapshot.isNullOrBlank()) {
+                try { setSenderId(senderIdSnapshot) } catch (ex: Throwable) { Log.w(TAG, "Unable to set senderId: ${ex.message}") }
+              }
+              if (!contactKeySnapshot.isNullOrBlank()) {
+                try { setDelayRegistrationUntilContactKeyIsSet(true) } catch (_: Throwable) { Log.w(TAG, "delayRegistrationUntilContactKeyIsSet unsupported") }
+              }
+              // Provide a basic NotificationCustomizationOptions to satisfy SDK requirement
+              try {
+                setNotificationCustomizationOptions(
+                  NotificationCustomizationOptions.create { ctx, notificationMessage: NotificationMessage ->
+                    val channel = NotificationManager.createDefaultNotificationChannel(ctx)
+                    NotificationManager.getDefaultNotificationBuilder(
+                      ctx,
+                      notificationMessage,
+                      channel,
+                      ctx.applicationInfo.icon
+                    )
+                  }
+                )
+              } catch (_: Throwable) {
+                // Fallback: attempt with default channel only
+                try {
+                  setNotificationCustomizationOptions(
+                    NotificationCustomizationOptions.create { ctx, notificationMessage: NotificationMessage ->
+                      NotificationManager.getDefaultNotificationBuilder(
+                        ctx,
+                        notificationMessage,
+                        NotificationManager.createDefaultNotificationChannel(ctx),
+                        ctx.applicationInfo.icon
+                      )
+                    }
+                  )
+                } catch (_: Throwable) {}
+              }
+              setAnalyticsEnabled(true)
+            }.build(appContext.reactContext!!.applicationContext)
+          }) { status ->
+            if (completed) return@configure
+            val rawStatus = try { status.status } catch (_: Throwable) { -999 }
+            val failed = isInitFailed(rawStatus)
+            val success = !failed
+            val failedOrdinal = InitializationStatus.Status.FAILED.ordinal
+            val successOrdinal = InitializationStatus.Status.SUCCESS.ordinal
+            Log.d(TAG, "Configure callback rawStatus=$rawStatus (FAILED.ordinal=$failedOrdinal SUCCESS.ordinal=$successOrdinal) failed=$failed -> treatingSuccess=$success")
+            if (success) {
+              try {
+                SFMCSdk.requestSdk { sdk ->
+                  sdk.identity.setProfileAttributes(savedAttributes)
+                  if (!savedContactKey.isNullOrBlank()) sdk.identity.setProfileId(savedContactKey)
+                  sdk.mp { newPush ->
+                    newPush.registrationManager.edit().apply {
+                      savedTags.forEach { addTag(it) }
+                      commit()
+                    }
+                    if (!savedToken.isNullOrBlank() && (senderIdSnapshot.isNullOrBlank() || newPush.pushMessageManager.pushToken != savedToken)) {
+                      Log.d(TAG, "Restoring push token (prevSender=$senderIdSnapshot)")
+                      try { newPush.pushMessageManager.setPushToken(savedToken) } catch (ex: Throwable) { Log.e(TAG, "Failed setting token", ex) }
+                    }
+                    if (wasPushEnabled) {
+                      try { newPush.pushMessageManager.enablePush() } catch (ex: Throwable) { Log.e(TAG, "Enable push failed", ex) }
+                    } else {
+                      try { newPush.pushMessageManager.disablePush() } catch (_: Throwable) {}
+                    }
+                  }
+                }
+                completed = true
+                timeoutRunnable?.let { handler.removeCallbacks(it) }
+                isMigratingBu = false
+                Log.d(TAG, "Migration succeeded for newAppId=$newAppId (attributes=${savedAttributes.size} tags=${savedTags.size})")
+                promise.resolve(mapOf(
+                  "success" to true,
+                  "newAppId" to newAppId,
+                  "carried" to mapOf(
+                    "contactKey" to (savedContactKey ?: null),
+                    "attributeCount" to savedAttributes.size,
+                    "tagCount" to savedTags.size,
+                    "tokenCarried" to (!savedToken.isNullOrBlank())
+                  ),
+                  "isPushEnabled" to wasPushEnabled
+                ))
+                // Persist new BU credentials as stored values for next cold start
+                try {
+                  val ctx = appContext.reactContext!!.applicationContext
+                  val p = ctx.getSharedPreferences("expo_marketingcloudsdk_bu", android.content.Context.MODE_PRIVATE)
+                  p.edit().apply {
+                    putString("storedAppId", newAppId)
+                    putString("storedAccessToken", newAccessToken)
+                    putString("storedServerUrl", normalizedServerUrl)
+                    if (!newMid.isNullOrBlank()) putString("storedMid", newMid) else remove("storedMid")
+                    apply()
+                  }
+                } catch (ex: Throwable) {
+                  Log.w(TAG, "Failed storing migrated BU: ${ex.message}")
+                }
+              } catch (ex: Throwable) {
+                completed = true
+                timeoutRunnable?.let { handler.removeCallbacks(it) }
+                isMigratingBu = false
+                Log.e(TAG, "Migration restore failed", ex)
+                promise.reject("ERR_MIGRATION_RESTORE", "Failed to restore data in new BU", ex)
+              }
+            } else {
+              completed = true
+              timeoutRunnable?.let { handler.removeCallbacks(it) }
+              isMigratingBu = false
+              try { SFMCSdk.requestSdk { sdk -> Log.e(TAG, "State after failed init=" + sdk.getSdkState().toString()) } } catch (_: Throwable) {}
+              Log.e(TAG, "Re-init failed for new BU newAppId=$newAppId serverUrl=$normalizedServerUrl mid=$newMid senderId=$senderIdSnapshot rawStatus=$rawStatus failedOrdinal=${InitializationStatus.Status.FAILED.ordinal}")
+              promise.reject("ERR_REINIT_FAILED", "Failed to initialize SDK with new BU (status=$rawStatus)", null)
+            }
+          }
+        }
+
+  tempListener = object: RegistrationEventListener {
+          override fun onRegistrationReceived(reg: Registration) {
+            if (!completed) {
+              if (!reg.pushEnabled) {
+                Log.d(TAG, "Registration event: push disabled -> proceeding to reconfigure")
+                reconfigureAndRestore(true)
+              } else if (wasPushEnabled && !startedReconfigure) {
+                Log.d(TAG, "Registration event: push still enabled, scheduling forced reconfigure in 500ms")
+                handler.postDelayed({ reconfigureAndRestore(true) }, 500)
+              }
+            }
+          }
+        }
+
+  tempListener?.let { mp.registrationManager.registerForRegistrationEvents(it) }
+        mp.pushMessageManager.disablePush()
+        // Force registration update attribute to encourage sync
+        mp.registrationManager.edit().apply {
+          setAttribute("bu_migration_ts", System.currentTimeMillis().toString())
+          commit()
+        }
+        Log.d(TAG, "Issued disablePush; added bu_migration_ts attribute to force registration update")
+
+        // If push already disabled, fast-path after small delay
+        if (!mp.pushMessageManager.isPushEnabled) {
+          Log.d(TAG, "Push already disabled; fast-path reconfigure in 400ms")
+          handler.postDelayed({ reconfigureAndRestore(true) }, 400)
+        }
+
+        // Retry disabling push a few times if still enabled (some devices/ROMs lag)
+        reDisableRunnable = object: Runnable {
+          override fun run() {
+            if (completed || startedReconfigure) return
+            if (!mp.pushMessageManager.isPushEnabled) return
+            if (reDisableAttempts >= MAX_REDISABLE_ATTEMPTS) return
+            reDisableAttempts += 1
+            try {
+              Log.d(TAG, "Re-disabling push attempt $reDisableAttempts")
+              mp.pushMessageManager.disablePush()
+              mp.registrationManager.edit().apply {
+                setAttribute("bu_migration_retry", System.currentTimeMillis().toString())
+                commit()
+              }
+            } catch (ex: Throwable) {
+              Log.e(TAG, "Error re-disabling push", ex)
+            }
+            handler.postDelayed(this, REDISABLE_RETRY_MS)
+          }
+        }
+        handler.postDelayed(reDisableRunnable!!, REDISABLE_RETRY_MS)
+
+        // Poll fallback every 2s in case registration event not received
+  pollRunnable = object: Runnable {
+          override fun run() {
+            if (completed) return
+            SFMCSdk.requestSdk { sdk -> sdk.mp { innerMp ->
+              if (!innerMp.pushMessageManager.isPushEnabled && !completed) {
+    Log.d(TAG, "Poll: detected push disabled -> reconfigure")
+    reconfigureAndRestore(true)
+              } else if (!startedReconfigure) {
+    handler.postDelayed(this, POLL_INTERVAL_MS)
+              }
+            } }
+          }
+        }
+  pollRunnable?.let { handler.postDelayed(it, POLL_INTERVAL_MS) }
+
+  // Force fallback reconfigure after internal FORCE_RECONFIGURE_MS even if push flag never flipped
+  handler.postDelayed({ if (!completed && !startedReconfigure) { Log.d(TAG, "Force fallback reconfigure trigger"); reconfigureAndRestore(true) } }, FORCE_RECONFIGURE_MS.toLong())
+
+        // Schedule timeout
+    timeoutRunnable = Runnable {
+          if (!completed) {
+            completed = true
+            pollRunnable?.let { handler.removeCallbacks(it) }
+      reDisableRunnable?.let { handler.removeCallbacks(it) }
+            try { tempListener?.let { mp.registrationManager.unregisterForRegistrationEvents(it) } } catch (_: Throwable) {}
+            if (wasPushEnabled) {
+              try { mp.pushMessageManager.enablePush() } catch (_: Throwable) {}
+            }
+            isMigratingBu = false
+      Log.e(TAG, "Migration timeout after ${MIGRATION_TIMEOUT_MS}ms")
+      promise.reject("ERR_MIGRATION_TIMEOUT", "BU migration timed out after ${MIGRATION_TIMEOUT_MS}ms", null)
+          }
+        }
+    timeoutRunnable?.let { handler.postDelayed(it, MIGRATION_TIMEOUT_MS.toLong()) }
+      }
+    }
+
     AsyncFunction("startObserving") {eventName: String? ->
       when (eventName) {
         "onLog" -> {
@@ -354,16 +648,69 @@ class ExpoMarketingCloudSdkModule : Module() {
         }
       }
     }
+
+  AsyncFunction("getStoredBu") { promise: Promise ->
+      try {
+        val ctx = appContext.reactContext!!.applicationContext
+        val p = ctx.getSharedPreferences("expo_marketingcloudsdk_bu", android.content.Context.MODE_PRIVATE)
+  val appId = p.getString("storedAppId", null)
+  val accessToken = p.getString("storedAccessToken", null)
+  val serverUrl = p.getString("storedServerUrl", null)
+  val mid = p.getString("storedMid", null)
+        if (appId == null || accessToken == null || serverUrl == null) {
+          promise.resolve(null)
+        } else {
+          promise.resolve(mapOf(
+            "appId" to appId,
+            "accessToken" to accessToken,
+            "serverUrl" to serverUrl,
+            "mid" to mid
+          ))
+        }
+      } catch (ex: Throwable) {
+        promise.reject("ERR_GET_STORED_BU", "Failed to get stored BU", ex)
+      }
+    }
+
+    AsyncFunction("clearStoredBu") { promise: Promise ->
+      try {
+        val ctx = appContext.reactContext!!.applicationContext
+        ctx.getSharedPreferences("expo_marketingcloudsdk_bu", android.content.Context.MODE_PRIVATE).edit().apply {
+          remove("storedAppId")
+          remove("storedAccessToken")
+          remove("storedServerUrl")
+          remove("storedMid")
+          apply()
+        }
+        promise.resolve(true)
+      } catch (ex: Throwable) {
+        promise.reject("ERR_CLEAR_STORED_BU", "Failed to clear stored BU", ex)
+      }
+    }
   }
 
   private fun whenPushModuleReady(promise: Promise?, callback: (mp: PushModuleInterface) -> Unit) {
-    SFMCSdk.requestSdk { sdk -> sdk.mp {mp ->
-      if (mp.initializationStatus.status == InitializationStatus.Status.FAILED) {
+    SFMCSdk.requestSdk { sdk -> sdk.mp { mp ->
+      if (isInitFailed(mp.initializationStatus.status)) {
+        // Ensure migration flag is cleared if we were attempting a migration when init failed
+        isMigratingBu = false
         promise?.reject("ERR_SFMC_SDK_INIT", "Marketing Cloud Push Module failed to initialize", null)
       } else {
         callback(mp)
       }
     } }
+  }
+
+  private fun isInitSuccess(raw: Any?): Boolean = when (raw) {
+    is InitializationStatus.Status -> raw == InitializationStatus.Status.SUCCESS
+    is Int -> raw == InitializationStatus.Status.SUCCESS.ordinal
+    else -> false
+  }
+
+  private fun isInitFailed(raw: Any?): Boolean = when (raw) {
+    is InitializationStatus.Status -> raw == InitializationStatus.Status.FAILED
+    is Int -> raw == InitializationStatus.Status.FAILED.ordinal
+    else -> false
   }
 
   private fun messagesToJSValue(messages: List<InboxMessage>): List<Map<String, Any?>> {

--- a/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
+++ b/android/src/main/java/expo/modules/marketingcloudsdk/ExpoMarketingCloudSdkModule.kt
@@ -23,6 +23,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.serialization.json.*
 import java.text.SimpleDateFormat
 import org.json.JSONObject
+import android.os.SystemClock
 
 
 class ExpoMarketingCloudSdkModule : Module() {
@@ -229,6 +230,7 @@ class ExpoMarketingCloudSdkModule : Module() {
       val POLL_INTERVAL_MS = 2_000L
       val REDISABLE_RETRY_MS = 3_000L
       val MAX_REDISABLE_ATTEMPTS = 3
+      val MIN_DISABLE_SETTLE_MS = 1_500L
       val TAG = "ExpoMCSdkMigration"
 
   if (newAppId.isNullOrBlank() || newAccessToken.isNullOrBlank() || newServerUrl.isNullOrBlank()) {
@@ -254,18 +256,23 @@ class ExpoMarketingCloudSdkModule : Module() {
         val wasPushEnabled = mp.pushMessageManager.isPushEnabled
         var previousSenderId: String? = null
         var previousAppId: String? = null
-        SFMCSdk.requestSdk { sdk ->
-          try {
-            val state = sdk.getSdkState()
-            val pushObj: JSONObject? = state.optJSONObject("PUSH")
-            val initConfig = pushObj?.optJSONObject("initConfig")
-            previousSenderId = initConfig?.optString("senderId")?.takeIf { !it.isNullOrBlank() }
-            previousAppId = initConfig?.optString("applicationId")
-            Log.d(TAG, "Previous state: appId=$previousAppId senderId=$previousSenderId")
-          } catch (ex: Throwable) {
-            Log.w(TAG, "Failed parsing previous sdk state: ${ex.message}")
+        try {
+          SFMCSdk.requestSdk { sdk ->
+            try {
+              val state = sdk.getSdkState()
+              val pushObj: JSONObject? = state.optJSONObject("PUSH")
+              val initConfig = pushObj?.optJSONObject("initConfig")
+              previousSenderId = initConfig?.optString("senderId")?.takeIf { !it.isNullOrBlank() }
+              previousAppId = initConfig?.optString("applicationId")
+              if (previousAppId.isNullOrBlank()) { // fallback to module identity
+                try { previousAppId = mp.moduleIdentity.applicationId } catch (_: Throwable) {}
+              }
+              Log.d(TAG, "Previous state: appId=$previousAppId senderId=$previousSenderId")
+            } catch (ex: Throwable) {
+              Log.w(TAG, "Failed parsing previous sdk state: ${ex.message}")
+            }
           }
-        }
+        } catch (_: Throwable) {}
         val normalizedServerUrl = newServerUrl?.let { if (it.endsWith('/')) it else "$it/" }
         if (normalizedServerUrl == null) {
           // Safety check
@@ -275,6 +282,8 @@ class ExpoMarketingCloudSdkModule : Module() {
         }
   var completed = false
         val handler = android.os.Handler(android.os.Looper.getMainLooper())
+        var disableIssuedAt: Long = 0L
+        var gotRegistrationAfterDisable = false
 
   // Will hold registration listener so reconfigure helper can unregister it
   var tempListener: RegistrationEventListener? = null
@@ -421,8 +430,17 @@ class ExpoMarketingCloudSdkModule : Module() {
           override fun onRegistrationReceived(reg: Registration) {
             if (!completed) {
               if (!reg.pushEnabled) {
-                Log.d(TAG, "Registration event: push disabled -> proceeding to reconfigure")
-                reconfigureAndRestore(true)
+                // Only count registration events for the previous (old) BU prior to reconfigure
+                gotRegistrationAfterDisable = true
+                val elapsed = SystemClock.elapsedRealtime() - disableIssuedAt
+                val remaining = MIN_DISABLE_SETTLE_MS - elapsed
+                if (remaining > 0) {
+                  Log.d(TAG, "Registration event: push disabled; waiting extra ${remaining}ms before possible reconfigure (will check gotRegistrationAfterDisable)")
+                  handler.postDelayed({ if (gotRegistrationAfterDisable && !startedReconfigure) reconfigureAndRestore(true) }, remaining)
+                } else if (gotRegistrationAfterDisable && !startedReconfigure) {
+                  Log.d(TAG, "Registration event: push disabled & settle met -> proceeding to reconfigure")
+                  reconfigureAndRestore(true)
+                }
               } else if (wasPushEnabled && !startedReconfigure) {
                 Log.d(TAG, "Registration event: push still enabled, scheduling forced reconfigure in 500ms")
                 handler.postDelayed({ reconfigureAndRestore(true) }, 500)
@@ -432,18 +450,32 @@ class ExpoMarketingCloudSdkModule : Module() {
         }
 
   tempListener?.let { mp.registrationManager.registerForRegistrationEvents(it) }
-        mp.pushMessageManager.disablePush()
-        // Force registration update attribute to encourage sync
-        mp.registrationManager.edit().apply {
-          setAttribute("bu_migration_ts", System.currentTimeMillis().toString())
-          commit()
+        // Ensure we always create a state transition that triggers a server registration.
+        fun issueDisableSequence() {
+          disableIssuedAt = SystemClock.elapsedRealtime()
+          // Intentionally clear token first so the old BU receives a registration that removes the subscription.
+          try {
+            if (!savedToken.isNullOrBlank()) {
+              Log.d(TAG, "Clearing existing push token before disable to force unsubscribe on old BU")
+              mp.pushMessageManager.setPushToken("")
+            }
+          } catch (ex: Throwable) {
+            Log.w(TAG, "Failed clearing token prior to disable: ${ex.message}")
+          }
+          mp.pushMessageManager.disablePush()
+          mp.registrationManager.edit().apply {
+            setAttribute("bu_migration_ts", System.currentTimeMillis().toString())
+            commit()
+          }
+          Log.d(TAG, "Issued disablePush (after token clear); added bu_migration_ts attribute to force registration update")
         }
-        Log.d(TAG, "Issued disablePush; added bu_migration_ts attribute to force registration update")
-
-        // If push already disabled, fast-path after small delay
         if (!mp.pushMessageManager.isPushEnabled) {
-          Log.d(TAG, "Push already disabled; fast-path reconfigure in 400ms")
-          handler.postDelayed({ reconfigureAndRestore(true) }, 400)
+          // Force a toggle to guarantee an opt-out registration (old BU may still consider device opted-in)
+            Log.d(TAG, "Push already disabled at start; toggling enable->disable to force opt-out registration")
+            try { mp.pushMessageManager.enablePush() } catch (_: Throwable) {}
+            handler.postDelayed({ issueDisableSequence() }, 300)
+        } else {
+          issueDisableSequence()
         }
 
         // Retry disabling push a few times if still enabled (some devices/ROMs lag)
@@ -469,23 +501,42 @@ class ExpoMarketingCloudSdkModule : Module() {
         handler.postDelayed(reDisableRunnable!!, REDISABLE_RETRY_MS)
 
         // Poll fallback every 2s in case registration event not received
-  pollRunnable = object: Runnable {
+    pollRunnable = object: Runnable {
           override fun run() {
-            if (completed) return
             SFMCSdk.requestSdk { sdk -> sdk.mp { innerMp ->
-              if (!innerMp.pushMessageManager.isPushEnabled && !completed) {
-    Log.d(TAG, "Poll: detected push disabled -> reconfigure")
-    reconfigureAndRestore(true)
-              } else if (!startedReconfigure) {
-    handler.postDelayed(this, POLL_INTERVAL_MS)
+      if (!innerMp.pushMessageManager.isPushEnabled && gotRegistrationAfterDisable) {
+                val elapsed = SystemClock.elapsedRealtime() - disableIssuedAt
+                val remaining = MIN_DISABLE_SETTLE_MS - elapsed
+                if (remaining > 0) {
+                  Log.d(TAG, "Poll: detected push disabled; reconfigure after settle remaining=${remaining}ms")
+                  handler.postDelayed({ reconfigureAndRestore(true) }, remaining)
+                } else {
+                  Log.d(TAG, "Poll: detected push disabled -> reconfigure")
+                  reconfigureAndRestore(true)
+                }
+              } else {
+                handler.postDelayed(this, POLL_INTERVAL_MS)
               }
             } }
           }
         }
-  pollRunnable?.let { handler.postDelayed(it, POLL_INTERVAL_MS) }
+        handler.postDelayed(pollRunnable, POLL_INTERVAL_MS)
 
-  // Force fallback reconfigure after internal FORCE_RECONFIGURE_MS even if push flag never flipped
-  handler.postDelayed({ if (!completed && !startedReconfigure) { Log.d(TAG, "Force fallback reconfigure trigger"); reconfigureAndRestore(true) } }, FORCE_RECONFIGURE_MS.toLong())
+        // Force fallback reconfigure after internal FORCE_RECONFIGURE_MS even if push flag never flipped
+        handler.postDelayed({
+          if (!completed && !startedReconfigure) {
+            if (gotRegistrationAfterDisable) {
+              Log.d(TAG, "Force fallback reconfigure trigger (registration observed)")
+              reconfigureAndRestore(true)
+            } else {
+              Log.d(TAG, "Force fallback reached but no registration event yet; extending wait 3s")
+              handler.postDelayed({ if (!completed && !startedReconfigure) {
+                Log.d(TAG, "Extended fallback reconfigure now executing (registrationObserved=$gotRegistrationAfterDisable)")
+                reconfigureAndRestore(true)
+              } }, 3000)
+            }
+          }
+        }, FORCE_RECONFIGURE_MS.toLong())
 
         // Schedule timeout
     timeoutRunnable = Runnable {

--- a/ios/ExpoMarketingCloudSdkAppDelegateSubscriber.swift
+++ b/ios/ExpoMarketingCloudSdkAppDelegateSubscriber.swift
@@ -7,18 +7,26 @@ public class ExpoMarketingCloudSdkAppDelegateSubscriber : ExpoAppDelegateSubscri
   private var notificationDelegate: ExpoMarketingCloudSdkNotificationsDelegate?
   
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+  let defaults = UserDefaults.standard
 
-    let debug = Bundle.main.object(forInfoDictionaryKey: "SFMCDebug") as? Bool ?? false;
-    let accessToken = Bundle.main.object(forInfoDictionaryKey: "SFMCAccessToken") as! String
-    let analyticsEnabled = Bundle.main.object(forInfoDictionaryKey: "SFMCAnalyticsEnabled") as? Bool ?? false;
-    let appId = Bundle.main.object(forInfoDictionaryKey: "SFMCApplicationId") as! String
-    let applicationControlsBadging = Bundle.main.object(forInfoDictionaryKey: "SFMCApplicationControlsBadging") as? Bool ?? false;
-    let delayRegistrationUntilContactKeyIsSet = Bundle.main.object(forInfoDictionaryKey: "SFMCDelayRegistrationUntilContactKeyIsSet") as? Bool ?? false;
-    let inboxEnabled = Bundle.main.object(forInfoDictionaryKey: "SFMCInboxEnabled") as? Bool ?? false;
-    let locationEnabled = Bundle.main.object(forInfoDictionaryKey: "SFMCLocationEnabled") as? Bool ?? false;
-    let mid = Bundle.main.object(forInfoDictionaryKey: "SFMCMid") as? String;
-    let serverUrl = URL(string: Bundle.main.object(forInfoDictionaryKey: "SFMCServerUrl") as! String)!;
-    let markMessageReadOnInboxNotificationOpen = Bundle.main.object(forInfoDictionaryKey: "SFMCMarkNotificationReadOnInboxNotificationOpen") as? Bool ?? false;
+  let storedAppId = defaults.string(forKey: "storedAppId")
+  let storedAccessToken = defaults.string(forKey: "storedAccessToken")
+  let storedServerUrlStr = defaults.string(forKey: "storedServerUrl")
+  let storedMid = defaults.string(forKey: "storedMid")
+
+  let debug = Bundle.main.object(forInfoDictionaryKey: "SFMCDebug") as? Bool ?? false
+  let accessToken = storedAccessToken ?? (Bundle.main.object(forInfoDictionaryKey: "SFMCAccessToken") as! String)
+  let analyticsEnabled = Bundle.main.object(forInfoDictionaryKey: "SFMCAnalyticsEnabled") as? Bool ?? false
+  let appId = storedAppId ?? (Bundle.main.object(forInfoDictionaryKey: "SFMCApplicationId") as! String)
+  let applicationControlsBadging = Bundle.main.object(forInfoDictionaryKey: "SFMCApplicationControlsBadging") as? Bool ?? false
+  let delayRegistrationUntilContactKeyIsSet = Bundle.main.object(forInfoDictionaryKey: "SFMCDelayRegistrationUntilContactKeyIsSet") as? Bool ?? false
+  let inboxEnabled = Bundle.main.object(forInfoDictionaryKey: "SFMCInboxEnabled") as? Bool ?? false
+  let locationEnabled = Bundle.main.object(forInfoDictionaryKey: "SFMCLocationEnabled") as? Bool ?? false
+  let mid = (storedMid?.isEmpty == false ? storedMid : (Bundle.main.object(forInfoDictionaryKey: "SFMCMid") as? String))
+  let baseServerStr = storedServerUrlStr ?? (Bundle.main.object(forInfoDictionaryKey: "SFMCServerUrl") as! String)
+  let normalizedServer = baseServerStr.hasSuffix("/") ? baseServerStr : baseServerStr + "/"
+  let serverUrl = URL(string: normalizedServer)!
+  let markMessageReadOnInboxNotificationOpen = Bundle.main.object(forInfoDictionaryKey: "SFMCMarkNotificationReadOnInboxNotificationOpen") as? Bool ?? false
 
     if (debug) {
       // Enable logging for debugging early on. Debug level is not recommended for production apps, as significant data

--- a/ios/ExpoMarketingCloudSdkModule.swift
+++ b/ios/ExpoMarketingCloudSdkModule.swift
@@ -10,6 +10,8 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
   private var refreshInboxPromise: Promise?
   private var logger: ExpoMarketingCloudSdkLogger?
   private var defaultLogLevel: LogLevel = LogLevel.none
+  // Prevent concurrent BU migrations
+  private var isMigratingBu: Bool = false
   
   // Each module class must implement the definition function. The definition consists of components
   // that describes the module's functionality and behavior.
@@ -125,6 +127,208 @@ public class ExpoMarketingCloudSdkModule: Module, ExpoMarketingCloudSdkLoggerDel
       SFMCSdk.requestPushSdk { mp in
         promise.resolve(mp.attributes())
       }
+    }
+
+    AsyncFunction("migrateBu") { (config: [String: Any], promise: Promise) in
+      // Basic expected keys
+      guard let newAppId = config["appId"] as? String, !newAppId.isEmpty else {
+        promise.reject("ERR_INVALID_CONFIG", "Missing appId in config")
+        return
+      }
+      guard let newAccessToken = config["accessToken"] as? String, !newAccessToken.isEmpty else {
+        promise.reject("ERR_INVALID_CONFIG", "Missing accessToken in config")
+        return
+      }
+      guard let serverUrlStrRaw = config["serverUrl"] as? String, let serverUrlTmp = URL(string: serverUrlStrRaw) else {
+        promise.reject("ERR_INVALID_CONFIG", "Missing or invalid serverUrl in config")
+        return
+      }
+      // Normalize server url to always have trailing slash to match Android convention
+      let serverUrlStr = serverUrlStrRaw.hasSuffix("/") ? serverUrlStrRaw : serverUrlStrRaw + "/"
+      let newServerUrl = URL(string: serverUrlStr)!
+      let newMid = config["mid"] as? String
+
+      if self.isMigratingBu {
+        promise.reject("ERR_MIGRATION_IN_PROGRESS", "A BU migration is already in progress")
+        return
+      }
+
+      // Ensure SDK is operational before starting migration
+      if SFMCSdk.mp.getStatus() != .operational {
+        promise.reject("ERR_SDK_NOT_READY", "SDK is not operational; initialize before migrating")
+        return
+      }
+
+      self.isMigratingBu = true
+
+  // Internal timings (self-sufficient; not exposed via TS typings)
+  let timeoutMs = 30000 // overall guard timeout
+  let forceReconfigureAfterMs = 8000 // early forced reconfigure fallback
+
+      // Capture current data to carry over
+      var savedContactKey: String? = nil
+      var savedTags: [String] = []
+      var savedAttributes: [String: String] = [:]
+  var savedToken: String? = nil
+      var wasPushEnabled: Bool = false
+      var completed = false
+      var timeoutWorkItem: DispatchWorkItem?
+
+      SFMCSdk.requestPushSdk { mp in
+        wasPushEnabled = mp.pushEnabled()
+        savedContactKey = mp.contactKey()
+        if let tagsSet = mp.tags() {
+          // Convert AnyHashable elements to String safely
+          savedTags = tagsSet.compactMap { $0 as? String }
+        }
+        if let attrs = mp.attributes() {
+          // Safely cast only string key/value pairs
+          attrs.forEach { key, value in
+            if let k = key as? String, let v = value as? String {
+              savedAttributes[k] = v
+            }
+          }
+        }
+  savedToken = mp.deviceToken()
+
+        // Helper closure to proceed with reconfiguration once push is disabled
+        var proceedMigration: ((Bool) -> Void)? = nil
+        proceedMigration = { [weak self] skipPushCheck in
+          if completed { return }
+          if !skipPushCheck && mp.pushEnabled() { return } // ensure actually disabled unless forced
+          completed = true
+          mp.unsetRegistrationCallback()
+
+          // Build new push config
+          var pushBuilder = PushConfigBuilder(appId: newAppId)
+            .setAccessToken(newAccessToken)
+            .setMarketingCloudServerUrl(newServerUrl)
+          if let mid = newMid, !mid.isEmpty { pushBuilder = pushBuilder.setMid(mid) }
+
+          SFMCSdk.initializeSdk(ConfigBuilder().setPush(config: pushBuilder.build(), onCompletion: { result in
+            switch result {
+            case .success:
+              // Restore carried data in new context
+              if let ck = savedContactKey { SFMCSdk.identity.setProfileId(ck) }
+              savedAttributes.forEach { (k,v) in SFMCSdk.identity.setProfileAttribute(k, v) }
+              SFMCSdk.requestPushSdk { newMp in
+                savedTags.forEach { _ = newMp.addTag($0) }
+                if let tokenString = savedToken, let tokenObj = try? ExpoMarketingCloudSdkDeviceToken(hexString: tokenString) {
+                  newMp.setDeviceToken(tokenObj.data)
+                }
+                newMp.setPushEnabled(wasPushEnabled)
+                timeoutWorkItem?.cancel()
+                self?.isMigratingBu = false
+                let carried: [String: Any] = [
+                  "contactKey": savedContactKey as Any,
+                  "attributeCount": savedAttributes.count,
+                  "tagCount": savedTags.count,
+                  "tokenCarried": savedToken != nil
+                ]
+                let result: [String: Any] = [
+                  "success": true,
+                  "newAppId": newAppId,
+                  "carried": carried,
+                  "isPushEnabled": wasPushEnabled
+                ]
+                promise.resolve(result)
+                // Persist stored BU credentials for next cold start
+                let d = UserDefaults.standard
+                d.set(newAppId, forKey: "storedAppId")
+                d.set(newAccessToken, forKey: "storedAccessToken")
+                d.set(newServerUrl.absoluteString, forKey: "storedServerUrl")
+                if let mid = newMid, !mid.isEmpty {
+                  d.set(mid, forKey: "storedMid")
+                } else {
+                  d.removeObject(forKey: "storedMid")
+                }
+              }
+            default:
+              timeoutWorkItem?.cancel()
+              self?.isMigratingBu = false
+              promise.reject("ERR_REINIT_FAILED", "Failed to initialize SDK with new BU credentials")
+            }
+          }).build())
+        }
+
+        // Register one-off callback to detect opt-out registration
+        mp.setRegistrationCallback { _ in
+          // Only proceed after push disabled (opt-out completed)
+          if mp.pushEnabled() == false && !completed { proceedMigration?(false) }
+        }
+
+        // Disable push to trigger opt-out registration event
+        mp.setPushEnabled(false)
+        // Force a registration update by setting a transient attribute to encourage server sync
+        let ts = Int(Date().timeIntervalSince1970 * 1000)
+        SFMCSdk.identity.setProfileAttribute("bu_migration_ts", "\(ts)")
+
+        // Force fallback reconfigure after forceReconfigureAfterMs even if push flag never turned false
+        let forceWorkItem = DispatchWorkItem { [weak self] in
+          if !completed {
+            proceedMigration?(true) // skip push enabled check
+          }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(forceReconfigureAfterMs), execute: forceWorkItem)
+
+        // Poll fallback: in case registration callback never fires, periodically check pushEnabled
+        let pollInterval: TimeInterval = 2.0
+        var elapsed: Int = 0
+        let maxElapsed = timeoutMs // ms
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+        timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
+        timer.setEventHandler {
+          if completed { timer.cancel(); return }
+          elapsed += Int(pollInterval * 1000)
+          SFMCSdk.requestPushSdk { innerMp in
+            if !innerMp.pushEnabled() { proceedMigration?(false) }
+          }
+          if elapsed >= maxElapsed { timer.cancel() }
+        }
+        timer.resume()
+
+        // Schedule timeout guard
+        let workItem = DispatchWorkItem { [weak self] in
+          if !completed {
+            completed = true
+            mp.unsetRegistrationCallback()
+            // Restore original push state if needed
+            if wasPushEnabled { mp.setPushEnabled(true) }
+            self?.isMigratingBu = false
+            promise.reject("ERR_MIGRATION_TIMEOUT", "BU migration timed out after \(timeoutMs) ms (pushEnabled may never have flipped)")
+          }
+        }
+        timeoutWorkItem = workItem
+  DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(timeoutMs), execute: workItem)
+      }
+    }
+
+    AsyncFunction("getStoredBu") { (promise: Promise) in
+      let d = UserDefaults.standard
+  // Read stored keys only (legacy keys removed)
+  let appId = d.string(forKey: "storedAppId")
+  let accessToken = d.string(forKey: "storedAccessToken")
+  let serverUrl = d.string(forKey: "storedServerUrl")
+      if appId == nil || accessToken == nil || serverUrl == nil {
+        promise.resolve(nil)
+        return
+      }
+  let mid = d.string(forKey: "storedMid")
+      promise.resolve([
+        "appId": appId as Any,
+        "accessToken": accessToken as Any,
+        "serverUrl": serverUrl as Any,
+        "mid": mid as Any
+      ])
+    }
+
+    AsyncFunction("clearStoredBu") { (promise: Promise) in
+      let d = UserDefaults.standard
+      d.removeObject(forKey: "storedAppId")
+      d.removeObject(forKey: "storedAccessToken")
+      d.removeObject(forKey: "storedServerUrl")
+      d.removeObject(forKey: "storedMid")
+      promise.resolve(true)
     }
 
     AsyncFunction("addTag") { (tag: String, promise: Promise) in

--- a/src/ExpoMarketingCloudSdk.types.ts
+++ b/src/ExpoMarketingCloudSdk.types.ts
@@ -44,6 +44,25 @@ export type InboxResponsePayload = {
   messages: InboxMessage[]
 }
 
+export type BuConfig = {
+  appId: string;
+	accessToken: string;
+	serverUrl: string;
+	mid?: string;
+}
+
+export type BuMigrationResponse = {
+  success: boolean;
+	newAppId: string;
+	carried: {
+		contactKey: string | null | undefined;
+		attributeCount: number;
+		tagCount: number;
+		tokenCarried: boolean;
+	};
+	isPushEnabled: boolean;
+}
+
 export type RegistrationResponseSucceededPayload = {
   response: {
     "quietPushEnabled" : boolean,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import ExpoMarketingCloudSdkModule from './ExpoMarketingCloudSdkModule';
-import { InboxResponsePayload, LogEventPayload, InboxMessage, RegistrationResponseSucceededPayload } from './ExpoMarketingCloudSdk.types';
+import { InboxResponsePayload, LogEventPayload, InboxMessage, RegistrationResponseSucceededPayload, BuConfig, BuMigrationResponse } from './ExpoMarketingCloudSdk.types';
 
 export { isSfmcNotificationResponse } from './notifications/helpers/isSfmcNotificationResponse'
 export { extractPayloadFromSfmcNotificationResponse } from './notifications/helpers/extractPayloadFromSfmcNotificationResponse'
@@ -150,4 +150,16 @@ export function addRegistrationResponseSucceededListener(listener: (event: Regis
   return ExpoMarketingCloudSdkModule.addListener('onRegistrationResponseSucceeded', listener)
 }
 
-export { LogEventPayload, InboxResponsePayload, InboxMessage, RegistrationResponseSucceededPayload }
+export function migrateBu(config: BuConfig): Promise<BuMigrationResponse> {
+  return ExpoMarketingCloudSdkModule.migrateBu(config);
+}
+
+export function getStoredBu(): Promise<BuConfig | null> {
+  return ExpoMarketingCloudSdkModule.getStoredBu();
+}
+
+export function clearStoredBu(): Promise<boolean> {
+  return ExpoMarketingCloudSdkModule.clearStoredBu();
+}
+
+export { LogEventPayload, InboxResponsePayload, InboxMessage, RegistrationResponseSucceededPayload, BuConfig, BuMigrationResponse }


### PR DESCRIPTION
**Changes Made**
This PR adds runtime Business Unit (BU) migration support meaning the user can now switch Salesforce Marketing Cloud Business Units from the app. These BU creds will persist across app launches meaning the next time the app is launched instead of initialising SFMC with the creds provided in the app config it initialises with the values from the migrated BU.

**Why these changes are being made**
Some apps need to re-point the SDK to a different BU (e.g. environment switch, regional tenancy, user-driven org selection) while retaining user state (contact key, attributes, tags, push token, push enabled state).

**Key Changes**

- Native (iOS / Android): BU migration flow with state carry-over.
- New APIs: migrateBu, getStoredBu, clearStoredBu.
- Types: BuConfig, BuMigrationResponse.
- Persistence: Stores last migrated BU in UserDefaults / SharedPreferences.
- README: New section “Business Unit (BU) Migration)”.

**Behavior Notes**

- serverUrl is normalized to include trailing slash.
- Migration attempts to disable push, reconfigure, restore state, then re-enable push if it was previously enabled.
- Timeout + safety fallbacks (poll, forced reconfigure) to avoid hanging if registration callbacks do not arrive.
- On success BU credentials are persisted for next cold start.
- clearStoredBu reverts to static plugin config next launch.

**Testing**
Currently for our workflow, we have patched the package with this change and tested that it works. 
