### PR TITLE
Support for Expo 55

### DIFF
--- a/ios/ExpoMarketingCloudSdk.podspec
+++ b/ios/ExpoMarketingCloudSdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'EXNotifications'
+  s.dependency 'ExpoNotifications'
   s.dependency 'MarketingCloudSDK', '9.0.3'
   s.dependency 'MarketingCloud-SFMCSdk', '2.0.2'
 

--- a/ios/ExpoMarketingCloudSdkAppDelegateSubscriber.swift
+++ b/ios/ExpoMarketingCloudSdkAppDelegateSubscriber.swift
@@ -1,5 +1,5 @@
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 import SFMCSDK
 import MarketingCloudSDK
 

--- a/ios/ExpoMarketingCloudSdkNotificationsDelegate.swift
+++ b/ios/ExpoMarketingCloudSdkNotificationsDelegate.swift
@@ -1,5 +1,5 @@
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 import SFMCSDK
 import MarketingCloudSDK
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@allboatsrise/expo-marketingcloudsdk",
   "author": "All Boats Rise Inc.",
-  "version": "54.0.1",
+  "version": "55.0.0",
   "license": "MIT",
   "description": "Expo module for Salesforce Marketing Cloud SDK",
   "homepage": "https://github.com/allboatsrise/expo-marketingcloudsdk",
@@ -48,15 +48,15 @@
   "devDependencies": {
     "@types/react": "~19.1.0",
     "expo-module-scripts": "^5.0.7",
-    "expo-notifications": "^0.32.12",
-    "expo": "^54.0.10",
-    "react-native": "0.81.4",
-    "zod": "~3.15.0"
+    "expo-notifications": "~55.0.12",
+    "expo": "^55.0.0",
+    "react-native": "0.83.2",
+    "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "expo": ">=54.0.10",
-    "expo-notifications": ">=0.32.12",
-    "zod": "^3.15.0"
+    "expo": "^55.0.0",
+    "expo-notifications": ">=55.0.12",
+    "zod": "^3.24.1"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/src/ExpoMarketingCloudSdkModule.ts
+++ b/src/ExpoMarketingCloudSdkModule.ts
@@ -1,7 +1,9 @@
 import { NativeModule, requireNativeModule } from 'expo';
 import { ExpoMarketingCloudSdkModuleEvents } from './ExpoMarketingCloudSdk.types';
 
-declare class ExpoMarketingCloudSdkModule extends NativeModule<ExpoMarketingCloudSdkModuleEvents> {}
+declare class ExpoMarketingCloudSdkModule extends NativeModule<ExpoMarketingCloudSdkModuleEvents> {
+    [key: string]: any;
+}
 
 // This call loads the native module object from the JSI.
 export default requireNativeModule<ExpoMarketingCloudSdkModule>('ExpoMarketingCloudSdk');

--- a/src/notifications/helpers/isSfmcNotificationResponse.ts
+++ b/src/notifications/helpers/isSfmcNotificationResponse.ts
@@ -9,7 +9,7 @@ import {
 export const isSfmcAndroidNotificationResponse = (
   notificationResponse: NotificationResponse
 ): notificationResponse is SfmcAndroidNotificationResponse => {
-  const payload: unknown = notificationResponse.notification.request.content.data.payload
+  const payload: unknown = notificationResponse.notification.request.content.data?.payload
   return isSfmcNotificationResponseBasePayload(payload)
 }
 


### PR DESCRIPTION
This PR adds support for [Expo 55](https://expo.dev/changelog/sdk-55).

- Upgraded the modules `expo`, `expo-notifications`, `react-native` and `zod`.
- Updated dependency in `ios/ExpoMarketingCloudSdk.podspec` since the new `expo-notifications` version updated its pod name from `EXNotifications` to `ExpoNotifications`
- Added optional chaining in `src/notifications/helpers/isSfmcNotificationResponse.ts` to avoid compilation error.
- Added index signature in `src/ExpoMarketingCloudSdkModule.ts` to avoid compilation error.